### PR TITLE
#125 Vanity URLs are not pulled in for organizers - fix

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/fragment/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/InfoFragment.java
@@ -203,9 +203,10 @@ public class InfoFragment extends SherlockFragment {
                                     } else {
                                         try {
                                             mFetchOrganizerInfo.addParameter(getUrlFromPersonUrl(url));
-                                            if(isAdded());
                                         } catch(Exception ex) {
+                                            if(isAdded()) {
                                                 Crouton.makeText(getActivity(), String.format(getString(R.string.bogus_organizer), url.getValue()), Style.ALERT);
+                                            }
                                         }
                                     }
                                 } else {


### PR DESCRIPTION
Hello, I could not run the test in my device/emulator but I think we only need to return the entire url if it contains the new user url else we will still return the same value used before.

Please review and tell me if I was wrong :)
