### PR TITLE
use utf-8 as default encoding fixes #147

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/api/GsonRequest.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GsonRequest.java
@@ -124,7 +124,7 @@ public class GsonRequest<Input, Output> extends GdgRequest<Output> {
                     HttpHeaderParser.parseCacheHeaders(response));
         }
         try {
-            String json = new String(response.data, HttpHeaderParser.parseCharset(response.headers));
+            String json = new String(response.data, "UTF-8");
             return (Response<Output>)Response.success(mGson.fromJson(json, mClazz),
                     HttpHeaderParser.parseCacheHeaders(response));
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
I will leave this pull request in order to fix this ASAP, but as my comment says:
### **original comment from #147**

we are obtaining the charset from the response header:

this is at **GsonRequest.java** line number: **127**

```
    String json = new String(response.data, HttpHeaderParser.parseCharset(response.headers));
```

when we parse the charset from the response headers we obtain: **ISO-8859-1\**\* should we start using only utf-8 and not obtaining info from the headers? :hammer: 

**\**\* according to [volley documentation](https://android.googlesource.com/platform/frameworks/volley/+/master/src/com/android/volley/toolbox/HttpHeaderParser.java) the method parseCharset returns: ISO-8859-1 as default when no Content-Type is returned in the header, I think we should open a bug at [hub](https://github.com/gdg-x/hub) and fix there but if you ask me... I would prefer to work only in utf-8
