### PR TITLE
Update SDK to 24.0.2, extract version numbers into variables for easier maintanance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk7
 branches:
   only:
     - master
-    - release
+    - develop
 
 before_install:
   - SDK_TOOLS_VERSION=24.0.2


### PR DESCRIPTION
Android SDK Tools got a minor update to 24.0.2.
While updating this I extracted all version numbers into variables to ease future maintanance on this file.

Also updating the config to include the develop branch, our integration branch for the next version.
