### PR TITLE
Fix broken build because of missing cardview-v7 lib.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     compile 'com.google.apis:google-api-services-youtube:v3-rev106-1.18.0-rc'
     compile 'com.google.api-client:google-api-client-android:1.18.0-rc'
     compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:cardview-v7:21.0.3'
     compile 'com.android.support:mediarouter-v7:21.0.3'
     compile 'com.google.android.apps.dashclock:dashclock-api:2.0.0'
     compile 'com.squareup:otto:1.3.4'


### PR DESCRIPTION
Add cardview-v7 to build.gradle to fix "No resource identifier found for... attribute 'cardCornerRadius'" compilation error.