### PR TITLE
chore: replace  plugin 'android' with 'com.android.application'

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 apply plugin: 'versions'
 


### PR DESCRIPTION
Plugin 'android' is deprecated and Android Studio suggested the replacement.