### PR TITLE
Migrate to android environment on Travis rather than java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
     # - sys-img-x86-android-21
 
 before_script:
-    - GRADLE_OPTS=-Xmx512m -XX:MaxPermSize=256m
+    - GRADLE_OPTS="-Xmx512m -XX:MaxPermSize=256m"
 
 script: "./gradlew clean build"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
-language: java
-jdk: oraclejdk7
+language: android
+
+android:
+  components:
+    - android-21
+    - build-tools-21.1.2
+    - platform-tools
+    - extra-google-m2repository
+    - extra-android-m2repository
+
+    # Specify at least one system image,
+    # if you need to run emulator(s) during your tests
+    # - sys-img-x86-android-21
+
+script: "./gradlew clean build"
 
 branches:
   only:
     - master
     - develop
-
-before_install:
-  - SDK_TOOLS_VERSION=24.0.2
-  - BUILD_TOOLS_VERSION=21.1.2
-  - COMPILE_SDK_VERSION=21
-  - sudo apt-get update -qq
-  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch; fi
-  # download the latest android sdk and unzip
-  - wget https://dl.google.com/android/android-sdk_r$SDK_TOOLS_VERSION-linux.tgz
-  - tar xzf android-sdk_r$SDK_TOOLS_VERSION-linux.tgz
-  - export ANDROID_HOME=`pwd`/android-sdk-linux
-  - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-  - echo "y" | android update sdk --filter platform-tools,build-tools-$BUILD_TOOLS_VERSION,android-$COMPILE_SDK_VERSION,extra-android-support,extra-android-m2repository,extra-google-m2repository --no-ui --obsolete --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ android:
     # if you need to run emulator(s) during your tests
     # - sys-img-x86-android-21
 
+before_script:
+    - GRADLE_OPTS="-Xmx1024m -XX:MaxPermSize=512m"
+
 script: "./gradlew clean build"
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
 before_script:
     - GRADLE_OPTS="-Xms40m -Xmx1536m -XX:MaxPermSize=1536m"
 
-script: "./gradlew clean build"
+script: "./gradlew clean build -Dpre-dex=false"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ android:
     # if you need to run emulator(s) during your tests
     # - sys-img-x86-android-21
 
+before_script:
+    - GRADLE_OPTS=-Xmx512m -XX:MaxPermSize=256m
+
 script: "./gradlew clean build"
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ android:
     # if you need to run emulator(s) during your tests
     # - sys-img-x86-android-21
 
-before_script:
-    - GRADLE_OPTS="-Xmx512m -XX:MaxPermSize=256m"
-
 script: "./gradlew clean build"
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
     # - sys-img-x86-android-21
 
 before_script:
-    - GRADLE_OPTS="-Xmx1024m -XX:MaxPermSize=512m"
+    - GRADLE_OPTS="-Xms40m -Xmx1536m -XX:MaxPermSize=1536m"
 
 script: "./gradlew clean build"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,3 +116,8 @@ dependencies {
     }
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }
+
+compileJava {
+    options.fork = true  // Fork your compilation into a child process
+    options.forkOptions.setMemoryMaximumSize("2g") // Set maximum memory to 2g
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,8 +116,3 @@ dependencies {
     }
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }
-
-compileJava {
-    options.fork = true  // Fork your compilation into a child process
-    options.forkOptions.setMemoryMaximumSize("2g") // Set maximum memory to 2g
-}


### PR DESCRIPTION
This PR moves the travis build from Java environment to the android one, currently still in beta.

This will hopefully will reduce the build time significantly as there is almost no download required.

![](http://media.giphy.com/media/9H2J2Dkln0nGE/giphy.gif)

More info can be found here: http://docs.travis-ci.com/user/languages/android/