### PR TITLE
Update Copyright to 2015

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/achievements/AchievementActionHandler.java
+++ b/app/src/main/java/org/gdg/frisbee/android/achievements/AchievementActionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/activity/AboutActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/AboutActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdlActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdlActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/activity/SearchActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/SearchActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ package org.gdg.frisbee.android.activity;
 import android.app.SearchManager;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
+
 import org.gdg.frisbee.android.R;
+
 import timber.log.Timber;
 
 public class SearchActivity extends GdgNavDrawerActivity {

--- a/app/src/main/java/org/gdg/frisbee/android/activity/SpecialEventActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/SpecialEventActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/activity/YoutubeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/YoutubeActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/ChapterAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/ChapterAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/ContributorAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/ContributorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013, 2015 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/EventAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/EventAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/GdlAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/GdlAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/NewsAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/NewsAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/PulseAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/PulseAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/ApiException.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/ApiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/ApiRequest.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/ApiRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,8 @@
 package org.gdg.frisbee.android.api;
 
 import com.android.volley.Request;
-import org.gdg.frisbee.android.app.GdgVolley;
 
-import java.util.ArrayList;
+import org.gdg.frisbee.android.app.GdgVolley;
 
 /**
  * Created with IntelliJ IDEA.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GapiOkTransport.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GapiOkTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GapiTransportChooser.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GapiTransportChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgRequest.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgTrustManager.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgX.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 GDG[x]
+ * Copyright 2013-2015 GDG[x]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GoogleDevelopersLive.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GoogleDevelopersLive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/OkStack.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/OkStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/deserializer/DateTimeDeserializer.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/deserializer/DateTimeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/deserializer/DateTimeSerializer.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/deserializer/DateTimeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/deserializer/ZuluDateTimeDeserializer.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/deserializer/ZuluDateTimeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/Chapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/Chapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/Directory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/Directory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/Event.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/GcmRegistrationRequest.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/GcmRegistrationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/GdgResponse.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/GdgResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/Geo.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/Geo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/HomeGdgRequest.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/HomeGdgRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/MessageResponse.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/MessageResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/Pulse.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/Pulse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/PulseEntry.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/PulseEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/app/BackupAgent.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/BackupAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/app/GdgVolley.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/GdgVolley.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
+++ b/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/AboutFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/AboutFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/ChangelogFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/ChangelogFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/ContributorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/ContributorsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/EventFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/EventFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/ExtLibrariesFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/ExtLibrariesFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/FullImageDialogFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/FullImageDialogFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/GdgListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/GdgListFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/GdlListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/GdlListFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/GetInvolvedFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/GetInvolvedFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/InfoFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/NewsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/NewsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/PulseFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,16 @@ package org.gdg.frisbee.android.fragment;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
+
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
 
-import butterknife.ButterKnife;
-import de.keyboardsurfer.android.widget.crouton.Crouton;
-import de.keyboardsurfer.android.widget.crouton.Style;
+import java.util.Map;
+
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.activity.MainActivity;
 import org.gdg.frisbee.android.activity.PulseActivity;
@@ -40,9 +39,11 @@ import org.gdg.frisbee.android.api.model.PulseEntry;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.joda.time.DateTime;
-import timber.log.Timber;
 
-import java.util.Map;
+import butterknife.ButterKnife;
+import de.keyboardsurfer.android.widget.crouton.Crouton;
+import de.keyboardsurfer.android.widget.crouton.Style;
+import timber.log.Timber;
 
 public class PulseFragment extends GdgListFragment {
 

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SeasonsGreetingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SeasonsGreetingsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/TranslatorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/TranslatorsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/graphics/drawable/RoundCornerDrawable.java
+++ b/app/src/main/java/org/gdg/frisbee/android/graphics/drawable/RoundCornerDrawable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/graphics/drawable/VignetteDrawable.java
+++ b/app/src/main/java/org/gdg/frisbee/android/graphics/drawable/VignetteDrawable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/provider/GdgProvider.java
+++ b/app/src/main/java/org/gdg/frisbee/android/provider/GdgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/task/Builder.java
+++ b/app/src/main/java/org/gdg/frisbee/android/task/Builder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/task/CommonAsyncTask.java
+++ b/app/src/main/java/org/gdg/frisbee/android/task/CommonAsyncTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/utils/ScopedBus.java
+++ b/app/src/main/java/org/gdg/frisbee/android/utils/ScopedBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/utils/Utils.java
+++ b/app/src/main/java/org/gdg/frisbee/android/utils/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.gdg.frisbee.android.utils;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
@@ -27,11 +26,6 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
-import org.gdg.frisbee.android.Const;
-import org.gdg.frisbee.android.R;
-import org.joda.time.DateTime;
-import org.joda.time.Period;
-import org.joda.time.format.DateTimeFormat;
 
 import java.io.*;
 import java.net.URL;
@@ -40,6 +34,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.gdg.frisbee.android.R;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
 
 /**
  * GDG Aachen

--- a/app/src/main/java/org/gdg/frisbee/android/view/AnimationImageView.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/AnimationImageView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/view/GdgCalendarView.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/GdgCalendarView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/view/MasonryView.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/MasonryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/view/MyView.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/MyView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/view/SquaredImageView.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/SquaredImageView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/org/gdg/frisbee/android/widget/UpcomingEventWidgetProvider.java
+++ b/app/src/main/java/org/gdg/frisbee/android/widget/UpcomingEventWidgetProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The GDG Frisbee Project
+ * Copyright 2013-2015 The GDG Frisbee Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/res/anim/fade_in.xml
+++ b/app/src/main/res/anim/fade_in.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/anim/fade_out.xml
+++ b/app/src/main/res/anim/fade_out.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/activated_background_holo_light.xml
+++ b/app/src/main/res/drawable/activated_background_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/btn_check_holo_light.xml
+++ b/app/src/main/res/drawable/btn_check_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/btn_default_holo_light.xml
+++ b/app/src/main/res/drawable/btn_default_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/btn_g_signin.xml
+++ b/app/src/main/res/drawable/btn_g_signin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/btn_radio_holo_light.xml
+++ b/app/src/main/res/drawable/btn_radio_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/btn_toggle_holo_light.xml
+++ b/app/src/main/res/drawable/btn_toggle_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/edit_text_holo_light.xml
+++ b/app/src/main/res/drawable/edit_text_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/fastscroll_thumb_holo.xml
+++ b/app/src/main/res/drawable/fastscroll_thumb_holo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/gdg_load.xml
+++ b/app/src/main/res/drawable/gdg_load.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/list_selector_background_transition_holo_light.xml
+++ b/app/src/main/res/drawable/list_selector_background_transition_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/list_selector_holo_light.xml
+++ b/app/src/main/res/drawable/list_selector_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/progress_horizontal_holo_light.xml
+++ b/app/src/main/res/drawable/progress_horizontal_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/progress_indeterminate_horizontal_holo_light.xml
+++ b/app/src/main/res/drawable/progress_indeterminate_horizontal_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/ratingbar_full_empty_holo_light.xml
+++ b/app/src/main/res/drawable/ratingbar_full_empty_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/ratingbar_full_filled_holo_light.xml
+++ b/app/src/main/res/drawable/ratingbar_full_filled_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/ratingbar_full_holo_light.xml
+++ b/app/src/main/res/drawable/ratingbar_full_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/ratingbar_holo_light.xml
+++ b/app/src/main/res/drawable/ratingbar_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/ratingbar_small_holo_light.xml
+++ b/app/src/main/res/drawable/ratingbar_small_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/scrubber_control_selector_holo_light.xml
+++ b/app/src/main/res/drawable/scrubber_control_selector_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/scrubber_progress_horizontal_holo_light.xml
+++ b/app/src/main/res/drawable/scrubber_progress_horizontal_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/spinner_background_holo_light.xml
+++ b/app/src/main/res/drawable/spinner_background_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/switch_inner_holo_light.xml
+++ b/app/src/main/res/drawable/switch_inner_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/switch_track_holo_light.xml
+++ b/app/src/main/res/drawable/switch_track_holo_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-land/activity_special.xml
+++ b/app/src/main/res/layout-land/activity_special.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-land/fragment_chapter_info.xml
+++ b/app/src/main/res/layout-land/fragment_chapter_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-land/fragment_news.xml
+++ b/app/src/main/res/layout-land/fragment_news.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-land/fragment_pulse.xml
+++ b/app/src/main/res/layout-land/fragment_pulse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-sw600dp-land/fragment_gdl_list.xml
+++ b/app/src/main/res/layout-sw600dp-land/fragment_gdl_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-sw800dp-land/fragment_gdl_list.xml
+++ b/app/src/main/res/layout-sw800dp-land/fragment_gdl_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_arrow.xml
+++ b/app/src/main/res/layout/activity_arrow.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_arrow_tagged.xml
+++ b/app/src/main/res/layout/activity_arrow_tagged.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_first_start.xml
+++ b/app/src/main/res/layout/activity_first_start.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_gde.xml
+++ b/app/src/main/res/layout/activity_gde.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_gdl.xml
+++ b/app/src/main/res/layout/activity_gdl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_special.xml
+++ b/app/src/main/res/layout/activity_special.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/activity_youtube.xml
+++ b/app/src/main/res/layout/activity_youtube.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/fragment_about_contributors.xml
+++ b/app/src/main/res/layout/fragment_about_contributors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/fragment_chapter_info.xml
+++ b/app/src/main/res/layout/fragment_chapter_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/fragment_gdl_list.xml
+++ b/app/src/main/res/layout/fragment_gdl_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/fragment_list.xml
+++ b/app/src/main/res/layout/fragment_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/fragment_pulse.xml
+++ b/app/src/main/res/layout/fragment_pulse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/list_event_item.xml
+++ b/app/src/main/res/layout/list_event_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/list_organizer_item.xml
+++ b/app/src/main/res/layout/list_organizer_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/list_tagged_organizer_item.xml
+++ b/app/src/main/res/layout/list_tagged_organizer_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/news_item_base.xml
+++ b/app/src/main/res/layout/news_item_base.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/organizer_item.xml
+++ b/app/src/main/res/layout/organizer_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/menu/event_context.xml
+++ b/app/src/main/res/menu/event_context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/menu/news_context.xml
+++ b/app/src/main/res/menu/news_context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-v11/gdg_themes.xml
+++ b/app/src/main/res/values-v11/gdg_themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/analytics.xml
+++ b/app/src/main/res/values/analytics.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/strings_untranslated.xml
+++ b/app/src/main/res/values/strings_untranslated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/styleable.xml
+++ b/app/src/main/res/values/styleable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2013 The GDG Frisbee Project
+  ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
Instead of removing the copyright from all the files as suggested in issue #182 I've done a "replace all" to change the copyright from 2013 to 2013-2015. Keeping the copyright in all the files doesn't seem that bad and it only requires one "replace all" and one commit per year to update. 
