### PR TITLE
Remove Chris Bane's Bitmap Cache library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,9 +85,6 @@ dependencies {
     compile ('de.keyboardsurfer.android.widget:crouton:1.8.4') {
         exclude module: 'support-v4'
     }
-    compile ('com.github.chrisbanes.bitmapcache:library:2.3'){
-        exclude module: 'support-v4'
-    }
     compile 'com.google:volley:4.3'
     compile 'com.google.android.analytics:analytics:3'
     compile 'com.jakewharton:disklrucache:2.0.2'

--- a/app/src/main/assets/third_party.html
+++ b/app/src/main/assets/third_party.html
@@ -140,21 +140,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
 See the License for the specific language governing permissions and<br/>
 limitations under the License.<br/><br/>
 
-<b>Android-BitmapCache</b><br/>
-Copyright 2011, 2012, 2013 Chris Banes<br/><br/>
-
-Licensed under the Apache License, Version 2.0 (the "License");<br/>
-you may not use this file except in compliance with the License.<br/>
-You may obtain a copy of the License at<br/><br/>
-
-http://www.apache.org/licenses/LICENSE-2.0<br/><br/>
-
-Unless required by applicable law or agreed to in writing, software<br/>
-distributed under the License is distributed on an "AS IS" BASIS,<br/>
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
-See the License for the specific language governing permissions and<br/>
-limitations under the License.<br/><br/>
-
 <b>DiskLruCache</b><br/>
 Copyright 2012 Jake Wharton<br/>
 Copyright 2011 The Android Open Source Project<br/><br/>

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -48,7 +48,6 @@ import java.io.File;
 
 import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;
-import uk.co.senab.bitmapcache.BitmapLruCache;
 
 /**
  * Created with IntelliJ IDEA.
@@ -64,7 +63,6 @@ public class App extends Application implements LocationListener {
         return mInstance;
     }
 
-    private BitmapLruCache mBitmapCache;
     private ModelCache mModelCache;
     private Picasso mPicasso;
     private SharedPreferences mPreferences;
@@ -112,7 +110,6 @@ public class App extends Application implements LocationListener {
 
         // Initialize ModelCache and Volley
         getModelCache();
-        getBitmapCache();
         GdgVolley.init(this);
 
         mPreferences.edit().putInt(Const.SETTINGS_APP_STARTS, mPreferences.getInt(Const.SETTINGS_APP_STARTS, 0) + 1).apply();
@@ -214,27 +211,6 @@ public class App extends Application implements LocationListener {
                     .build();
         }
         return mModelCache;
-    }
-
-    public BitmapLruCache getBitmapCache() {
-        if (mBitmapCache == null) {
-
-            String rootDir = null;
-            if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {
-                // SD-card available
-                rootDir = Environment.getExternalStorageDirectory().getAbsolutePath()
-                        + "/Android/data/" + getPackageName() + "/cache";
-            } else {
-                File internalCacheDir = getCacheDir();
-                rootDir = internalCacheDir.getAbsolutePath();
-            }
-
-            mBitmapCache = new BitmapLruCache.Builder(getApplicationContext())
-                    .setMemoryCacheEnabled(true)
-                    .setMemoryCacheMaxSizeUsingHeapSize()
-                    .build();
-        }
-        return mBitmapCache;
     }
 
     private void deleteDirectory(File dir) {

--- a/app/src/main/java/org/gdg/frisbee/android/app/GdgVolley.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/GdgVolley.java
@@ -17,14 +17,11 @@
 package org.gdg.frisbee.android.app;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.util.Log;
+
 import com.android.volley.RequestQueue;
-import com.android.volley.toolbox.ImageLoader;
 import com.android.volley.toolbox.Volley;
+
 import org.gdg.frisbee.android.api.GdgStack;
-import timber.log.Timber;
-import uk.co.senab.bitmapcache.CacheableBitmapDrawable;
 
 /**
  * GDG Aachen
@@ -43,8 +40,7 @@ public class GdgVolley {
         return mInstance;
     }
 
-    private RequestQueue mRequestQueue, mImageRequestQueue;
-    private ImageLoader mImageLoader;
+    private RequestQueue mRequestQueue;
 
     static void init(Context ctx) {
         mInstance = new GdgVolley(ctx);
@@ -52,32 +48,6 @@ public class GdgVolley {
 
     private GdgVolley(Context ctx) {
         mRequestQueue = Volley.newRequestQueue(ctx, new GdgStack());
-        mImageRequestQueue = Volley.newRequestQueue(ctx, new GdgStack());
-        mImageLoader = new ImageLoader(mImageRequestQueue, new ImageLoader.ImageCache() {
-            @Override
-            public Bitmap getBitmap(String url) {
-                // Check memcache here...disk cache lookup will be done by GdgStack
-                Timber.d("Looking up " + url + " in cache");
-                CacheableBitmapDrawable bitmap = App.getInstance().getBitmapCache().get(url);
-                if(bitmap != null) {
-                    Timber.d("Bitmap Memcache hit");
-                    return bitmap.getBitmap();
-                } else
-                    return null;
-            }
-
-            @Override
-            public void putBitmap(final String url, final Bitmap bitmap) {
-                new Thread() {
-                    @Override
-                    public void run() {
-                        String myurl = url.substring(6);
-                        Timber.d("Saving "+ myurl + " to cache");
-                        App.getInstance().getBitmapCache().put(myurl, bitmap);
-                    }
-                }.start();
-            }
-        });
     }
 
     public RequestQueue getRequestQueue() {
@@ -85,14 +55,6 @@ public class GdgVolley {
             return mRequestQueue;
         } else {
             throw new IllegalStateException("RequestQueue not initialized");
-        }
-    }
-
-    public ImageLoader getImageLoader() {
-        if (mImageLoader != null) {
-            return mImageLoader;
-        } else {
-            throw new IllegalStateException("ImageLoader not initialized");
         }
     }
 }


### PR DESCRIPTION
To address issue #190 I've removed Chris Bane's Bitmap Cache library from the project and now only Picasso is used for loading images.
When I have more time I'll also change from Volley to Retrofit but I'll work on other things first.