### PR TITLE
Remove NineOldAndroids dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,6 @@ dependencies {
     compile 'com.squareup:otto:1.3.4'
     compile 'com.squareup.okhttp:okhttp:1.6.0'
     compile 'com.squareup.okhttp:okhttp-urlconnection:1.6.0'
-    compile 'com.nineoldandroids:library:2.4.0'
     compile 'com.squareup.picasso:picasso:2.3.0'
     compile 'com.jakewharton:butterknife:5.1.0'
     compile 'com.google.zxing:android-integration:3.1.0'

--- a/app/src/main/assets/third_party.html
+++ b/app/src/main/assets/third_party.html
@@ -15,21 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
 See the License for the specific language governing permissions and<br/>
 limitations under the License.<br/><br/>
 
-<b>NineOldAndroid</b><br/>
-Copyright 2012 Jake Wharton<br/><br/>
-
-Licensed under the Apache License, Version 2.0 (the "License");<br/>
-you may not use this file except in compliance with the License.<br/>
-You may obtain a copy of the License at<br/><br/>
-
-http://www.apache.org/licenses/LICENSE-2.0<br/><br/>
-
-Unless required by applicable law or agreed to in writing, software<br/>
-distributed under the License is distributed on an "AS IS" BASIS,<br/>
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
-See the License for the specific language governing permissions and<br/>
-limitations under the License.<br/><br/>
-
 <b>ViewPagerIndicator</b><br/>
 Copyright 2012 Jake Wharton<br/>
 Copyright 2011 Patrik Åkerfeldt<br/>


### PR DESCRIPTION
NineOldAndroids was used by the old implementation of the pull to refresh pattern.
With the new implementation in PR #186 this library is not needed anymore.