### PR TITLE
Replace ViewPagerIndicator with SlidingTabLayout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,7 +115,6 @@ dependencies {
     compile 'com.nineoldandroids:library:2.4.0'
     compile 'com.jakewharton:butterknife:6.1.0'
     compile 'com.jakewharton.timber:timber:2.5.1'
-    compile 'com.viewpagerindicator:library:2.4.1@aar'
     compile 'com.jakewharton:disklrucache:2.0.2'
 
     //Others

--- a/app/src/main/assets/third_party.html
+++ b/app/src/main/assets/third_party.html
@@ -15,23 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
 See the License for the specific language governing permissions and<br/>
 limitations under the License.<br/><br/>
 
-<b>ViewPagerIndicator</b><br/>
-Copyright 2012 Jake Wharton<br/>
-Copyright 2011 Patrik Åkerfeldt<br/>
-Copyright 2011 Francisco Figueiredo Jr.<br/><br/>
-
-Licensed under the Apache License, Version 2.0 (the "License");<br/>
-you may not use this file except in compliance with the License.<br/>
-You may obtain a copy of the License at<br/><br/>
-
-http://www.apache.org/licenses/LICENSE-2.0<br/><br/>
-
-Unless required by applicable law or agreed to in writing, software<br/>
-distributed under the License is distributed on an "AS IS" BASIS,<br/>
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
-See the License for the specific language governing permissions and<br/>
-limitations under the License.<br/><br/>
-
 <b>Picasso</b><br/>
 Copyright 2013 Square, Inc.<br/><br/>
 

--- a/app/src/main/java/org/gdg/frisbee/android/activity/AboutActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/AboutActivity.java
@@ -24,8 +24,6 @@ import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.MenuItem;
 
-import com.viewpagerindicator.TitlePageIndicator;
-
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.fragment.AboutFragment;
 import org.gdg.frisbee.android.fragment.ChangelogFragment;
@@ -33,6 +31,7 @@ import org.gdg.frisbee.android.fragment.ContributorsFragment;
 import org.gdg.frisbee.android.fragment.ExtLibrariesFragment;
 import org.gdg.frisbee.android.fragment.GetInvolvedFragment;
 import org.gdg.frisbee.android.fragment.TranslatorsFragment;
+import org.gdg.frisbee.android.view.SlidingTabLayout;
 
 import butterknife.InjectView;
 
@@ -42,7 +41,7 @@ public class AboutActivity extends GdgActivity {
     ViewPager mViewPager;
 
     @InjectView(R.id.titles)
-    TitlePageIndicator mIndicator;
+    SlidingTabLayout mSlidingTabLayout;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -55,10 +54,11 @@ public class AboutActivity extends GdgActivity {
         getSupportActionBar().setDisplayUseLogoEnabled(true);
         getSupportActionBar().setTitle(R.string.about);
 
-        mIndicator.setOnPageChangeListener(this);
+
+        mSlidingTabLayout.setOnPageChangeListener(this);
 
         mViewPager.setAdapter(new AboutPagerAdapter(this, getSupportFragmentManager()));
-        mIndicator.setViewPager(mViewPager);
+        mSlidingTabLayout.setViewPager(mViewPager);
     }
 
     protected String getTrackedViewName() {

--- a/app/src/main/java/org/gdg/frisbee/android/activity/AboutActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/AboutActivity.java
@@ -40,7 +40,7 @@ public class AboutActivity extends GdgActivity {
     @InjectView(R.id.pager)
     ViewPager mViewPager;
 
-    @InjectView(R.id.titles)
+    @InjectView(R.id.sliding_tabs)
     SlidingTabLayout mSlidingTabLayout;
 
     @Override
@@ -54,7 +54,8 @@ public class AboutActivity extends GdgActivity {
         getSupportActionBar().setDisplayUseLogoEnabled(true);
         getSupportActionBar().setTitle(R.string.about);
 
-
+        mSlidingTabLayout.setCustomTabView(R.layout.tab_indicator, android.R.id.text1);
+        mSlidingTabLayout.setSelectedIndicatorColors(getResources().getColor(R.color.tab_selected_strip));
         mSlidingTabLayout.setOnPageChangeListener(this);
 
         mViewPager.setAdapter(new AboutPagerAdapter(this, getSupportFragmentManager()));

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
@@ -11,7 +11,6 @@ import android.util.SparseArray;
 
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
-import com.viewpagerindicator.TitlePageIndicator;
 
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.api.ApiRequest;
@@ -23,6 +22,7 @@ import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.fragment.GdeListFragment;
 import org.gdg.frisbee.android.fragment.PlainLayoutFragment;
 import org.gdg.frisbee.android.utils.Utils;
+import org.gdg.frisbee.android.view.SlidingTabLayout;
 import org.joda.time.DateTime;
 
 import java.lang.ref.WeakReference;
@@ -45,7 +45,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
     ViewPager mViewPager;
 
     @InjectView(R.id.titles)
-    TitlePageIndicator mIndicator;
+    SlidingTabLayout mSlidingTabLayout;
 
     private Handler mHandler = new Handler();
 
@@ -115,7 +115,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
                 mViewPagerAdapter.notifyDataSetChanged();
 
                 mViewPager.setAdapter(mViewPagerAdapter);
-                mIndicator.setViewPager(mViewPager);
+                mSlidingTabLayout.setViewPager(mViewPager);
             }
         });
     }
@@ -129,7 +129,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
         super.onResume();
         Timber.d("onResume()");
 
-        //mIndicator.setOnPageChangeListener(this);
+        //mSlidingTabLayout.setOnPageChangeListener(this);
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
@@ -38,7 +38,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
     @InjectView(R.id.pager)
     ViewPager mViewPager;
 
-    @InjectView(R.id.titles)
+    @InjectView(R.id.sliding_tabs)
     SlidingTabLayout mSlidingTabLayout;
 
     private Handler mHandler = new Handler();
@@ -53,6 +53,9 @@ public class GdeActivity extends GdgNavDrawerActivity {
 
         getSupportActionBar().setLogo(R.drawable.ic_gde_logo_wide);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        mSlidingTabLayout.setCustomTabView(R.layout.tab_indicator, android.R.id.text1);
+        mSlidingTabLayout.setSelectedIndicatorColors(getResources().getColor(R.color.tab_selected_strip));
 
         mViewPagerAdapter = new GdeCategoryAdapter(getSupportFragmentManager());
 
@@ -132,9 +135,16 @@ public class GdeActivity extends GdgNavDrawerActivity {
         Timber.d("onPause()");
     }
 
+    public interface Listener {
+        /**
+         * Called when the item has been selected in the ViewPager.
+         */
+        void onPageSelected();
+    }
+
     public class GdeCategoryAdapter extends FragmentStatePagerAdapter implements ViewPager.OnPageChangeListener {
-        private HashMap<String, GdeList> mGdeMap;
         private final SparseArray<WeakReference<Fragment>> mFragments = new SparseArray<>();
+        private HashMap<String, GdeList> mGdeMap;
 
         public GdeCategoryAdapter(FragmentManager fm) {
             super(fm);
@@ -202,12 +212,5 @@ public class GdeActivity extends GdgNavDrawerActivity {
         public void onPageScrollStateChanged(int i) {
         }
 
-    }
-
-    public interface Listener {
-        /**
-         * Called when the item has been selected in the ViewPager.
-         */
-        void onPageSelected();
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
@@ -1,6 +1,5 @@
 package org.gdg.frisbee.android.activity;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
@@ -34,12 +33,7 @@ import de.keyboardsurfer.android.widget.crouton.Crouton;
 import de.keyboardsurfer.android.widget.crouton.Style;
 import timber.log.Timber;
 
-/**
- * Created by maui on 28.05.2014.
- */
 public class GdeActivity extends GdgNavDrawerActivity {
-
-    private GdeDirectory mGdeDirectory;
 
     @InjectView(R.id.pager)
     ViewPager mViewPager;
@@ -60,10 +54,10 @@ public class GdeActivity extends GdgNavDrawerActivity {
         getSupportActionBar().setLogo(R.drawable.ic_gde_logo_wide);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        mViewPagerAdapter = new GdeCategoryAdapter(this, getSupportFragmentManager());
+        mViewPagerAdapter = new GdeCategoryAdapter(getSupportFragmentManager());
 
-        mGdeDirectory = new GdeDirectory();
-        final ApiRequest mFetchGdesTask = mGdeDirectory.getDirectory(new Response.Listener<GdeList>() {
+        final GdeDirectory gdeDirectory = new GdeDirectory();
+        final ApiRequest mFetchGdesTask = gdeDirectory.getDirectory(new Response.Listener<GdeList>() {
             @Override
             public void onResponse(final GdeList directory) {
                 App.getInstance().getModelCache().putAsync("gde_map", directory, DateTime.now().plusDays(4), new ModelCache.CachePutListener() {
@@ -103,8 +97,8 @@ public class GdeActivity extends GdgNavDrawerActivity {
             public void run() {
                 HashMap<String, GdeList> gdeMap = new HashMap<>();
 
-                for(Gde gde : directory) {
-                    if(!gdeMap.containsKey(gde.getProduct())) {
+                for (Gde gde : directory) {
+                    if (!gdeMap.containsKey(gde.getProduct())) {
                         gdeMap.put(gde.getProduct(), new GdeList());
                     }
 
@@ -139,16 +133,12 @@ public class GdeActivity extends GdgNavDrawerActivity {
     }
 
     public class GdeCategoryAdapter extends FragmentStatePagerAdapter implements ViewPager.OnPageChangeListener {
-        private Context mContext;
-
         private HashMap<String, GdeList> mGdeMap;
-        private final SparseArray<WeakReference<Fragment>> mFragments
-                = new SparseArray<WeakReference<Fragment>>();
+        private final SparseArray<WeakReference<Fragment>> mFragments = new SparseArray<>();
 
-        public GdeCategoryAdapter(Context ctx, FragmentManager fm) {
+        public GdeCategoryAdapter(FragmentManager fm) {
             super(fm);
-            mContext = ctx;
-            mGdeMap = new HashMap<String, GdeList>();
+            mGdeMap = new HashMap<>();
         }
 
         public void addMap(Map<String, GdeList> collection) {
@@ -157,17 +147,17 @@ public class GdeActivity extends GdgNavDrawerActivity {
 
         @Override
         public int getCount() {
-            return mGdeMap.keySet().size()+1;
+            return mGdeMap.keySet().size() + 1;
         }
 
         @Override
         public Fragment getItem(int position) {
-            if(position == 0) {
+            if (position == 0) {
                 return PlainLayoutFragment.newInstance(R.layout.fragment_gde_about);
             } else {
-                String key = mGdeMap.keySet().toArray(new String[0])[position-1];
+                String key = mGdeMap.keySet().toArray(new String[0])[position - 1];
                 Fragment frag = GdeListFragment.newInstance(mGdeMap.get(key), position == mViewPager.getCurrentItem());
-                mFragments.append(position, new WeakReference<Fragment>(frag));
+                mFragments.append(position, new WeakReference<>(frag));
 
                 return frag;
             }
@@ -175,10 +165,10 @@ public class GdeActivity extends GdgNavDrawerActivity {
 
         @Override
         public CharSequence getPageTitle(int position) {
-            if(position == 0) {
+            if (position == 0) {
                 return getString(R.string.about);
-            } else if(position > -1 && position-1 < mGdeMap.keySet().size()) {
-                String title = mGdeMap.keySet().toArray(new String[0])[position-1];
+            } else if (position > -1 && position - 1 < mGdeMap.keySet().size()) {
+                String title = mGdeMap.keySet().toArray(new String[0])[position - 1];
                 title = title.length() > 14 ? Utils.getUppercaseLetters(title) : title;
                 return title;
             } else {
@@ -194,11 +184,11 @@ public class GdeActivity extends GdgNavDrawerActivity {
         public void onPageSelected(int position) {
             if (position == 0) {
                 trackView("GDE/About");
-            } else  {
-                String key = mGdeMap.keySet().toArray(new String[0])[position-1];
+            } else {
+                String key = mGdeMap.keySet().toArray(new String[0])[position - 1];
                 trackView("GDE/" + key);
 
-                WeakReference<Fragment> ref = mFragments.get(position-1);
+                WeakReference<Fragment> ref = mFragments.get(position - 1);
                 Fragment frag = null != ref ? ref.get() : null;
 
                 // We need to notify the fragment that it is selected

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdgActivity.java
@@ -125,6 +125,7 @@ public abstract class GdgActivity extends TrackableActivity implements GoogleApi
 
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayShowTitleEnabled(false);
+            getSupportActionBar().setElevation(0);
         }
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
@@ -31,7 +31,6 @@ import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.viewpagerindicator.TitlePageIndicator;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
@@ -48,7 +47,12 @@ import org.gdg.frisbee.android.fragment.NewsFragment;
 import org.gdg.frisbee.android.fragment.SeasonsGreetingsFragment;
 import org.gdg.frisbee.android.utils.ChapterComparator;
 import org.gdg.frisbee.android.utils.Utils;
+import org.gdg.frisbee.android.view.SlidingTabLayout;
 import org.joda.time.DateTime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,7 +72,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
     ViewPager mViewPager;
 
     @InjectView(R.id.titles)
-    TitlePageIndicator mIndicator;
+    SlidingTabLayout mSlidingTabLayout;
 
     private Handler mHandler = new Handler();
 
@@ -97,7 +101,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
 
         mLocationComparator = new ChapterComparator(mPreferences);
 
-        mIndicator.setOnPageChangeListener(this);
+        mSlidingTabLayout.setOnPageChangeListener(this);
 
         mViewPagerAdapter = new MyAdapter(this, getSupportFragmentManager());
         mSpinnerAdapter = new ChapterAdapter(MainActivity.this, android.R.layout.simple_list_item_1);
@@ -167,7 +171,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
                 }
 
                 mViewPager.setAdapter(mViewPagerAdapter);
-                mIndicator.setViewPager(mViewPager);
+                mSlidingTabLayout.setViewPager(mViewPager);
             } else {
                 mFetchChaptersTask.execute();
             }
@@ -223,7 +227,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
         getSupportActionBar().setSelectedNavigationItem(mSpinnerAdapter.getPosition(chapter));
         mViewPager.setAdapter(mViewPagerAdapter);
         mViewPager.setOffscreenPageLimit(2);
-        mIndicator.setViewPager(mViewPager);
+        mSlidingTabLayout.setViewPager(mViewPager);
 
         if (SECTION_EVENTS.equals(getIntent().getStringExtra(Const.EXTRA_SECTION))) {
             mHandler.postDelayed(new Runnable() {

--- a/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
@@ -71,7 +71,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
     @InjectView(R.id.pager)
     ViewPager mViewPager;
 
-    @InjectView(R.id.titles)
+    @InjectView(R.id.sliding_tabs)
     SlidingTabLayout mSlidingTabLayout;
 
     private Handler mHandler = new Handler();
@@ -101,6 +101,9 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
 
         mLocationComparator = new ChapterComparator(mPreferences);
 
+        mSlidingTabLayout.setCustomTabView(R.layout.tab_indicator, android.R.id.text1);
+        mSlidingTabLayout.setSelectedIndicatorColors(getResources().getColor(R.color.tab_selected_strip));
+        mSlidingTabLayout.setDistributeEvenly(true);
         mSlidingTabLayout.setOnPageChangeListener(this);
 
         mViewPagerAdapter = new MyAdapter(this, getSupportFragmentManager());
@@ -327,22 +330,19 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
 
         @Override
         public int getCount() {
-            if (mSelectedChapter == null) {
-                return 0;
-            } else {
-                return 3;
-            }
+            return 3;
         }
 
         @Override
         public Fragment getItem(int position) {
+            String gplusId = mSelectedChapter == null ? "" : mSelectedChapter.getGplusId();
             switch (position) {
                 case 0:
-                    return NewsFragment.newInstance(mSelectedChapter.getGplusId());
+                    return NewsFragment.newInstance(gplusId);
                 case 1:
-                    return InfoFragment.newInstance(mSelectedChapter.getGplusId());
+                    return InfoFragment.newInstance(gplusId);
                 case 2:
-                    return EventFragment.newInstance(mSelectedChapter.getGplusId());
+                    return EventFragment.newInstance(gplusId);
             }
             return null;
         }

--- a/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
@@ -49,8 +49,6 @@ import timber.log.Timber;
 
 public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnNavigationListener {
 
-    private GroupDirectory mClient;
-
     private ArrayAdapter<String> mSpinnerAdapter;
 
     @InjectView(R.id.pager)
@@ -72,14 +70,14 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
 
         getSupportActionBar().setLogo(R.drawable.ic_logo_pulse);
 
-        mClient = new GroupDirectory();
+        final GroupDirectory mClient = new GroupDirectory();
 
         mSlidingTabLayout.setOnPageChangeListener(this);
 
-        mPulseTargets = new ArrayList<String>();
+        mPulseTargets = new ArrayList<>();
 
         mViewPagerAdapter = new MyAdapter(this, getSupportFragmentManager());
-        mSpinnerAdapter = new ArrayAdapter<String>(PulseActivity.this, android.R.layout.simple_list_item_1);
+        mSpinnerAdapter = new ArrayAdapter<>(PulseActivity.this, android.R.layout.simple_list_item_1);
         getSupportActionBar().setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
         getSupportActionBar().setListNavigationCallbacks(mSpinnerAdapter, PulseActivity.this);
 
@@ -87,30 +85,30 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
         getSupportActionBar().setHomeButtonEnabled(true);
 
         mFetchGlobalPulseTask = mClient.getPulse(new Response.Listener<Pulse>() {
-                @Override
-                public void onResponse(final Pulse pulse) {
-                    getSupportActionBar().setListNavigationCallbacks(mSpinnerAdapter, PulseActivity.this);
-                    App.getInstance().getModelCache().putAsync("pulse_global", pulse, DateTime.now().plusDays(1), new ModelCache.CachePutListener() {
-                         @Override
-                         public void onPutIntoCache() {
-                            mPulseTargets.addAll(pulse.keySet());
-                            initSpinner();
-                         }
-                    });
-                }
-            }, new Response.ErrorListener() {
-                @Override
-                public void onErrorResponse(VolleyError volleyError) {
-                    Crouton.makeText(PulseActivity.this, getString(R.string.fetch_chapters_failed), Style.ALERT).show();
-                    Timber.e("Could'nt fetch chapter list", volleyError);
-                }
-            }
+                                                     @Override
+                                                     public void onResponse(final Pulse pulse) {
+                                                         getSupportActionBar().setListNavigationCallbacks(mSpinnerAdapter, PulseActivity.this);
+                                                         App.getInstance().getModelCache().putAsync("pulse_global", pulse, DateTime.now().plusDays(1), new ModelCache.CachePutListener() {
+                                                             @Override
+                                                             public void onPutIntoCache() {
+                                                                 mPulseTargets.addAll(pulse.keySet());
+                                                                 initSpinner();
+                                                             }
+                                                         });
+                                                     }
+                                                 }, new Response.ErrorListener() {
+                                                     @Override
+                                                     public void onErrorResponse(VolleyError volleyError) {
+                                                         Crouton.makeText(PulseActivity.this, getString(R.string.fetch_chapters_failed), Style.ALERT).show();
+                                                         Timber.e("Could'nt fetch chapter list", volleyError);
+                                                     }
+                                                 }
         );
 
         App.getInstance().getModelCache().getAsync("pulse_global", true, new ModelCache.CacheListener() {
             @Override
             public void onGet(Object item) {
-                Pulse pulse = (Pulse)item;
+                Pulse pulse = (Pulse) item;
                 mPulseTargets.addAll(pulse.keySet());
                 initSpinner();
             }
@@ -134,13 +132,13 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
             pageName = "";
         }
 
-        return "Pulse/"+mViewPagerAdapter.getSelectedPulseTarget().replaceAll(" ", "-") +
+        return "Pulse/" + mViewPagerAdapter.getSelectedPulseTarget().replaceAll(" ", "-") +
                 "/" + pageName;
     }
 
     private void initSpinner() {
         Collections.sort(mPulseTargets);
-        mPulseTargets.add(0,"Global");
+        mPulseTargets.add(0, "Global");
         mViewPagerAdapter.setSelectedPulseTarget(mPulseTargets.get(0));
         mSpinnerAdapter.clear();
 
@@ -160,7 +158,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
         String previous = mViewPagerAdapter.getSelectedPulseTarget();
         getSupportActionBar().setSelectedNavigationItem(itemPosition);
         mViewPagerAdapter.setSelectedPulseTarget(mSpinnerAdapter.getItem(itemPosition));
-        if(!previous.equals(mSpinnerAdapter.getItem(itemPosition))) {
+        if (!previous.equals(mSpinnerAdapter.getItem(itemPosition))) {
             Timber.d("Switching chapter!");
             mViewPagerAdapter.notifyDataSetChanged();
         }
@@ -191,7 +189,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
 
         @Override
         public int getCount() {
-            if(mSelectedPulseTarget == null)
+            if (mSelectedPulseTarget == null)
                 return 0;
             else
                 return 3;
@@ -199,7 +197,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
 
         @Override
         public Fragment getItem(int position) {
-            switch(position) {
+            switch (position) {
                 case 0:
                     return PulseFragment.newInstance(0, mSelectedPulseTarget);
                 case 1:
@@ -212,7 +210,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
 
         @Override
         public CharSequence getPageTitle(int position) {
-            switch(position) {
+            switch (position) {
                 case 0:
                     return mContext.getText(R.string.pulse_events);
                 case 1:
@@ -228,7 +226,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
         }
 
         public void setSelectedPulseTarget(String pulseTarget) {
-            if(mSelectedPulseTarget != null)
+            if (mSelectedPulseTarget != null)
                 trackView();
 
             this.mSelectedPulseTarget = pulseTarget;

--- a/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
@@ -49,14 +49,11 @@ import timber.log.Timber;
 
 public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnNavigationListener {
 
-    private ArrayAdapter<String> mSpinnerAdapter;
-
     @InjectView(R.id.pager)
     ViewPager mViewPager;
-
-    @InjectView(R.id.titles)
+    @InjectView(R.id.sliding_tabs)
     SlidingTabLayout mSlidingTabLayout;
-
+    private ArrayAdapter<String> mSpinnerAdapter;
     private MyAdapter mViewPagerAdapter;
     private ArrayList<String> mPulseTargets;
     private ApiRequest mFetchGlobalPulseTask;
@@ -72,6 +69,8 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
 
         final GroupDirectory mClient = new GroupDirectory();
 
+        mSlidingTabLayout.setCustomTabView(R.layout.tab_indicator, android.R.id.text1);
+        mSlidingTabLayout.setSelectedIndicatorColors(getResources().getColor(R.color.tab_selected_strip));
         mSlidingTabLayout.setOnPageChangeListener(this);
 
         mPulseTargets = new ArrayList<>();

--- a/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
@@ -28,7 +28,6 @@ import android.widget.ArrayAdapter;
 
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
-import com.viewpagerindicator.TitlePageIndicator;
 
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.api.ApiRequest;
@@ -37,6 +36,7 @@ import org.gdg.frisbee.android.api.model.Pulse;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.fragment.PulseFragment;
+import org.gdg.frisbee.android.view.SlidingTabLayout;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
@@ -57,7 +57,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
     ViewPager mViewPager;
 
     @InjectView(R.id.titles)
-    TitlePageIndicator mIndicator;
+    SlidingTabLayout mSlidingTabLayout;
 
     private MyAdapter mViewPagerAdapter;
     private ArrayList<String> mPulseTargets;
@@ -74,7 +74,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
 
         mClient = new GroupDirectory();
 
-        mIndicator.setOnPageChangeListener(this);
+        mSlidingTabLayout.setOnPageChangeListener(this);
 
         mPulseTargets = new ArrayList<String>();
 
@@ -152,7 +152,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements ActionBar.OnN
             }
         }
         mViewPager.setAdapter(mViewPagerAdapter);
-        mIndicator.setViewPager(mViewPager);
+        mSlidingTabLayout.setViewPager(mViewPager);
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
@@ -24,12 +24,11 @@ import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.MenuItem;
 
-import com.viewpagerindicator.TitlePageIndicator;
-
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.activity.GdgActivity;
 import org.gdg.frisbee.android.api.GroupDirectory;
+import org.gdg.frisbee.android.view.SlidingTabLayout;
 
 import butterknife.InjectView;
 
@@ -47,7 +46,7 @@ public class EventActivity extends GdgActivity {
     ViewPager mViewPager;
 
     @InjectView(R.id.titles)
-    TitlePageIndicator mIndicator;
+    SlidingTabLayout mSlidingTabLayout;
 
     private EventPagerAdapter mViewPagerAdapter;
     private String mEventId;
@@ -65,16 +64,16 @@ public class EventActivity extends GdgActivity {
         getSupportActionBar().setTitle(R.string.event);
 
 
-        mIndicator.setOnPageChangeListener(this);
+        mSlidingTabLayout.setOnPageChangeListener(this);
 
         mViewPagerAdapter = new EventPagerAdapter(this, getSupportFragmentManager());
         mViewPager.setAdapter(mViewPagerAdapter);
-        mIndicator.setViewPager(mViewPager);
+        mSlidingTabLayout.setViewPager(mViewPager);
 
         mEventId = getIntent().getStringExtra(Const.EXTRA_EVENT_ID);
         String section = getIntent().getStringExtra(Const.EXTRA_SECTION);
         if (EventPagerAdapter.SECTION_OVERVIEW.equals(section)){
-            mIndicator.setCurrentItem(0);
+            mViewPager.setCurrentItem(0);
         }
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
@@ -36,7 +36,7 @@ public class EventActivity extends GdgActivity {
     @InjectView(R.id.pager)
     ViewPager mViewPager;
 
-    @InjectView(R.id.titles)
+    @InjectView(R.id.sliding_tabs)
     SlidingTabLayout mSlidingTabLayout;
 
     private String mEventId;
@@ -52,6 +52,8 @@ public class EventActivity extends GdgActivity {
         getSupportActionBar().setDisplayUseLogoEnabled(true);
         getSupportActionBar().setTitle(R.string.event);
 
+        mSlidingTabLayout.setCustomTabView(R.layout.tab_indicator, android.R.id.text1);
+        mSlidingTabLayout.setSelectedIndicatorColors(getResources().getColor(R.color.tab_selected_strip));
         mSlidingTabLayout.setOnPageChangeListener(this);
 
         final EventPagerAdapter mViewPagerAdapter = new EventPagerAdapter(this, getSupportFragmentManager());

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventActivity.java
@@ -27,19 +27,10 @@ import android.view.MenuItem;
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.activity.GdgActivity;
-import org.gdg.frisbee.android.api.GroupDirectory;
 import org.gdg.frisbee.android.view.SlidingTabLayout;
 
 import butterknife.InjectView;
 
-/**
- * GDG Aachen
- * org.gdg.frisbee.android.activity
- * <p/>
- * User: maui
- * Date: 22.04.13
- * Time: 23:03
- */
 public class EventActivity extends GdgActivity {
 
     @InjectView(R.id.pager)
@@ -48,9 +39,7 @@ public class EventActivity extends GdgActivity {
     @InjectView(R.id.titles)
     SlidingTabLayout mSlidingTabLayout;
 
-    private EventPagerAdapter mViewPagerAdapter;
     private String mEventId;
-    private GroupDirectory mClient;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -63,28 +52,27 @@ public class EventActivity extends GdgActivity {
         getSupportActionBar().setDisplayUseLogoEnabled(true);
         getSupportActionBar().setTitle(R.string.event);
 
-
         mSlidingTabLayout.setOnPageChangeListener(this);
 
-        mViewPagerAdapter = new EventPagerAdapter(this, getSupportFragmentManager());
+        final EventPagerAdapter mViewPagerAdapter = new EventPagerAdapter(this, getSupportFragmentManager());
         mViewPager.setAdapter(mViewPagerAdapter);
         mSlidingTabLayout.setViewPager(mViewPager);
 
         mEventId = getIntent().getStringExtra(Const.EXTRA_EVENT_ID);
         String section = getIntent().getStringExtra(Const.EXTRA_SECTION);
-        if (EventPagerAdapter.SECTION_OVERVIEW.equals(section)){
+        if (EventPagerAdapter.SECTION_OVERVIEW.equals(section)) {
             mViewPager.setCurrentItem(0);
         }
     }
 
     protected String getTrackedViewName() {
-        return "Event/"+getResources().getStringArray(R.array.about_tabs)[getCurrentPage()];
+        return "Event/" + getResources().getStringArray(R.array.about_tabs)[getCurrentPage()];
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 
-        if(item.getItemId() == android.R.id.home) {
+        if (item.getItemId() == android.R.id.home) {
             finish();
             return true;
         }
@@ -108,13 +96,12 @@ public class EventActivity extends GdgActivity {
 
         @Override
         public int getCount() {
-            int count = mContext.getResources().getStringArray(R.array.event_tabs).length;
             return 1;
         }
 
         @Override
         public Fragment getItem(int position) {
-            switch(position) {
+            switch (position) {
                 case 0:
                     return EventOverviewFragment.createFor(mEventId);
                 case 1:

--- a/app/src/main/java/org/gdg/frisbee/android/view/SlidingTabLayout.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/SlidingTabLayout.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gdg.frisbee.android.view;
+
+import android.content.Context;
+import android.graphics.Typeface;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.util.SparseArray;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.HorizontalScrollView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+/**
+ * To be used with ViewPager to provide a tab indicator component which give constant feedback as to
+ * the user's scroll progress.
+ * <p/>
+ * To use the component, simply add it to your view hierarchy. Then in your
+ * {@link android.app.Activity} or {@link android.support.v4.app.Fragment} call
+ * {@link #setViewPager(android.support.v4.view.ViewPager)} providing it the ViewPager this layout is being used for.
+ * <p/>
+ * The colors can be customized in two ways. The first and simplest is to provide an array of colors
+ * via {@link #setSelectedIndicatorColors(int...)}. The
+ * alternative is via the {@link org.gdg.frisbee.android.view.SlidingTabLayout.TabColorizer} interface which provides you complete control over
+ * which color is used for any individual position.
+ * <p/>
+ * The views used as tabs can be customized by calling {@link #setCustomTabView(int, int)},
+ * providing the layout ID of your custom layout.
+ */
+public class SlidingTabLayout extends HorizontalScrollView {
+    /**
+     * Allows complete control over the colors drawn in the tab layout. Set with
+     * {@link #setCustomTabColorizer(org.gdg.frisbee.android.view.SlidingTabLayout.TabColorizer)}.
+     */
+    public interface TabColorizer {
+
+        /**
+         * @return return the color of the indicator used when {@code position} is selected.
+         */
+        int getIndicatorColor(int position);
+
+    }
+
+    private static final int TITLE_OFFSET_DIPS = 24;
+    private static final int TAB_VIEW_PADDING_DIPS = 16;
+    private static final int TAB_VIEW_TEXT_SIZE_SP = 12;
+
+    private int mTitleOffset;
+
+    private int mTabViewLayoutId;
+    private int mTabViewTextViewId;
+    private boolean mDistributeEvenly;
+
+    private ViewPager mViewPager;
+    private SparseArray<String> mContentDescriptions = new SparseArray<String>();
+    private ViewPager.OnPageChangeListener mViewPagerPageChangeListener;
+
+    private final SlidingTabStrip mTabStrip;
+
+    public SlidingTabLayout(Context context) {
+        this(context, null);
+    }
+
+    public SlidingTabLayout(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public SlidingTabLayout(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+
+        // Disable the Scroll Bar
+        setHorizontalScrollBarEnabled(false);
+        // Make sure that the Tab Strips fills this View
+        setFillViewport(true);
+
+        mTitleOffset = (int) (TITLE_OFFSET_DIPS * getResources().getDisplayMetrics().density);
+
+        mTabStrip = new SlidingTabStrip(context);
+        addView(mTabStrip, LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+    }
+
+    /**
+     * Set the custom {@link org.gdg.frisbee.android.view.SlidingTabLayout.TabColorizer} to be used.
+     * <p/>
+     * If you only require simple custmisation then you can use
+     * {@link #setSelectedIndicatorColors(int...)} to achieve
+     * similar effects.
+     */
+    public void setCustomTabColorizer(TabColorizer tabColorizer) {
+        mTabStrip.setCustomTabColorizer(tabColorizer);
+    }
+
+    public void setDistributeEvenly(boolean distributeEvenly) {
+        mDistributeEvenly = distributeEvenly;
+    }
+
+    /**
+     * Sets the colors to be used for indicating the selected tab. These colors are treated as a
+     * circular array. Providing one color will mean that all tabs are indicated with the same color.
+     */
+    public void setSelectedIndicatorColors(int... colors) {
+        mTabStrip.setSelectedIndicatorColors(colors);
+    }
+
+    /**
+     * Set the {@link android.support.v4.view.ViewPager.OnPageChangeListener}. When using {@link org.gdg.frisbee.android.view.SlidingTabLayout} you are
+     * required to set any {@link android.support.v4.view.ViewPager.OnPageChangeListener} through this method. This is so
+     * that the layout can update it's scroll position correctly.
+     *
+     * @see android.support.v4.view.ViewPager#setOnPageChangeListener(android.support.v4.view.ViewPager.OnPageChangeListener)
+     */
+    public void setOnPageChangeListener(ViewPager.OnPageChangeListener listener) {
+        mViewPagerPageChangeListener = listener;
+    }
+
+    /**
+     * Set the custom layout to be inflated for the tab views.
+     *
+     * @param layoutResId Layout id to be inflated
+     * @param textViewId  id of the {@link android.widget.TextView} in the inflated view
+     */
+    public void setCustomTabView(int layoutResId, int textViewId) {
+        mTabViewLayoutId = layoutResId;
+        mTabViewTextViewId = textViewId;
+    }
+
+    /**
+     * Sets the associated view pager. Note that the assumption here is that the pager content
+     * (number of tabs and tab titles) does not change after this call has been made.
+     */
+    public void setViewPager(ViewPager viewPager) {
+        mTabStrip.removeAllViews();
+
+        mViewPager = viewPager;
+        if (viewPager != null) {
+            viewPager.setOnPageChangeListener(new InternalViewPagerListener());
+            populateTabStrip();
+        }
+    }
+
+    /**
+     * Create a default view to be used for tabs. This is called if a custom tab view is not set via
+     * {@link #setCustomTabView(int, int)}.
+     */
+    protected TextView createDefaultTabView(Context context) {
+        TextView textView = new TextView(context);
+        textView.setGravity(Gravity.CENTER);
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, TAB_VIEW_TEXT_SIZE_SP);
+        textView.setTypeface(Typeface.DEFAULT_BOLD);
+        textView.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        TypedValue outValue = new TypedValue();
+        getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackground,
+                outValue, true);
+        textView.setBackgroundResource(outValue.resourceId);
+        textView.setAllCaps(true);
+
+        int padding = (int) (TAB_VIEW_PADDING_DIPS * getResources().getDisplayMetrics().density);
+        textView.setPadding(padding, padding, padding, padding);
+
+        return textView;
+    }
+
+    private void populateTabStrip() {
+        final PagerAdapter adapter = mViewPager.getAdapter();
+        final OnClickListener tabClickListener = new TabClickListener();
+
+        for (int i = 0; i < adapter.getCount(); i++) {
+            View tabView = null;
+            TextView tabTitleView = null;
+
+            if (mTabViewLayoutId != 0) {
+                // If there is a custom tab view layout id set, try and inflate it
+                tabView = LayoutInflater.from(getContext()).inflate(mTabViewLayoutId, mTabStrip,
+                        false);
+                tabTitleView = (TextView) tabView.findViewById(mTabViewTextViewId);
+            }
+
+            if (tabView == null) {
+                tabView = createDefaultTabView(getContext());
+            }
+
+            if (tabTitleView == null && TextView.class.isInstance(tabView)) {
+                tabTitleView = (TextView) tabView;
+            }
+
+            if (mDistributeEvenly) {
+                LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams) tabView.getLayoutParams();
+                lp.width = 0;
+                lp.weight = 1;
+            }
+
+            tabTitleView.setText(adapter.getPageTitle(i));
+            tabView.setOnClickListener(tabClickListener);
+            String desc = mContentDescriptions.get(i, null);
+            if (desc != null) {
+                tabView.setContentDescription(desc);
+            }
+
+            mTabStrip.addView(tabView);
+            if (i == mViewPager.getCurrentItem()) {
+                tabView.setSelected(true);
+            }
+        }
+    }
+
+    public void setContentDescription(int i, String desc) {
+        mContentDescriptions.put(i, desc);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        if (mViewPager != null) {
+            scrollToTab(mViewPager.getCurrentItem(), 0);
+        }
+    }
+
+    private void scrollToTab(int tabIndex, int positionOffset) {
+        final int tabStripChildCount = mTabStrip.getChildCount();
+        if (tabStripChildCount == 0 || tabIndex < 0 || tabIndex >= tabStripChildCount) {
+            return;
+        }
+
+        View selectedChild = mTabStrip.getChildAt(tabIndex);
+        if (selectedChild != null) {
+            int targetScrollX = selectedChild.getLeft() + positionOffset;
+
+            if (tabIndex > 0 || positionOffset > 0) {
+                // If we're not at the first child and are mid-scroll, make sure we obey the offset
+                targetScrollX -= mTitleOffset;
+            }
+
+            scrollTo(targetScrollX, 0);
+        }
+    }
+
+    private class InternalViewPagerListener implements ViewPager.OnPageChangeListener {
+        private int mScrollState;
+
+        @Override
+        public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+            int tabStripChildCount = mTabStrip.getChildCount();
+            if ((tabStripChildCount == 0) || (position < 0) || (position >= tabStripChildCount)) {
+                return;
+            }
+
+            mTabStrip.onViewPagerPageChanged(position, positionOffset);
+
+            View selectedTitle = mTabStrip.getChildAt(position);
+            int extraOffset = (selectedTitle != null)
+                    ? (int) (positionOffset * selectedTitle.getWidth())
+                    : 0;
+            scrollToTab(position, extraOffset);
+
+            if (mViewPagerPageChangeListener != null) {
+                mViewPagerPageChangeListener.onPageScrolled(position, positionOffset,
+                        positionOffsetPixels);
+            }
+        }
+
+        @Override
+        public void onPageScrollStateChanged(int state) {
+            mScrollState = state;
+
+            if (mViewPagerPageChangeListener != null) {
+                mViewPagerPageChangeListener.onPageScrollStateChanged(state);
+            }
+        }
+
+        @Override
+        public void onPageSelected(int position) {
+            if (mScrollState == ViewPager.SCROLL_STATE_IDLE) {
+                mTabStrip.onViewPagerPageChanged(position, 0f);
+                scrollToTab(position, 0);
+            }
+            for (int i = 0; i < mTabStrip.getChildCount(); i++) {
+                mTabStrip.getChildAt(i).setSelected(position == i);
+            }
+            if (mViewPagerPageChangeListener != null) {
+                mViewPagerPageChangeListener.onPageSelected(position);
+            }
+        }
+
+    }
+
+    private class TabClickListener implements OnClickListener {
+        @Override
+        public void onClick(View v) {
+            for (int i = 0; i < mTabStrip.getChildCount(); i++) {
+                if (v == mTabStrip.getChildAt(i)) {
+                    mViewPager.setCurrentItem(i);
+                    return;
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/org/gdg/frisbee/android/view/SlidingTabLayout.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/SlidingTabLayout.java
@@ -18,6 +18,7 @@ package org.gdg.frisbee.android.view;
 
 import android.content.Context;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
@@ -174,7 +175,9 @@ public class SlidingTabLayout extends HorizontalScrollView {
         getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackground,
                 outValue, true);
         textView.setBackgroundResource(outValue.resourceId);
-        textView.setAllCaps(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            textView.setAllCaps(true);
+        }
 
         int padding = (int) (TAB_VIEW_PADDING_DIPS * getResources().getDisplayMetrics().density);
         textView.setPadding(padding, padding, padding, padding);

--- a/app/src/main/java/org/gdg/frisbee/android/view/SlidingTabStrip.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/SlidingTabStrip.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gdg.frisbee.android.view;
+
+import android.R;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.View;
+import android.widget.LinearLayout;
+
+class SlidingTabStrip extends LinearLayout {
+
+    private static final int DEFAULT_BOTTOM_BORDER_THICKNESS_DIPS = 0;
+    private static final byte DEFAULT_BOTTOM_BORDER_COLOR_ALPHA = 0x26;
+    private static final int SELECTED_INDICATOR_THICKNESS_DIPS = 3;
+    private static final int DEFAULT_SELECTED_INDICATOR_COLOR = 0xFF33B5E5;
+
+    private final int mBottomBorderThickness;
+    private final Paint mBottomBorderPaint;
+
+    private final int mSelectedIndicatorThickness;
+    private final Paint mSelectedIndicatorPaint;
+
+    private final int mDefaultBottomBorderColor;
+
+    private int mSelectedPosition;
+    private float mSelectionOffset;
+
+    private SlidingTabLayout.TabColorizer mCustomTabColorizer;
+    private final SimpleTabColorizer mDefaultTabColorizer;
+
+    SlidingTabStrip(Context context) {
+        this(context, null);
+    }
+
+    SlidingTabStrip(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setWillNotDraw(false);
+
+        final float density = getResources().getDisplayMetrics().density;
+
+        TypedValue outValue = new TypedValue();
+        context.getTheme().resolveAttribute(R.attr.colorForeground, outValue, true);
+        final int themeForegroundColor = outValue.data;
+
+        mDefaultBottomBorderColor = setColorAlpha(themeForegroundColor,
+                DEFAULT_BOTTOM_BORDER_COLOR_ALPHA);
+
+        mDefaultTabColorizer = new SimpleTabColorizer();
+        mDefaultTabColorizer.setIndicatorColors(DEFAULT_SELECTED_INDICATOR_COLOR);
+
+        mBottomBorderThickness = (int) (DEFAULT_BOTTOM_BORDER_THICKNESS_DIPS * density);
+        mBottomBorderPaint = new Paint();
+        mBottomBorderPaint.setColor(mDefaultBottomBorderColor);
+
+        mSelectedIndicatorThickness = (int) (SELECTED_INDICATOR_THICKNESS_DIPS * density);
+        mSelectedIndicatorPaint = new Paint();
+    }
+
+    void setCustomTabColorizer(SlidingTabLayout.TabColorizer customTabColorizer) {
+        mCustomTabColorizer = customTabColorizer;
+        invalidate();
+    }
+
+    void setSelectedIndicatorColors(int... colors) {
+        // Make sure that the custom colorizer is removed
+        mCustomTabColorizer = null;
+        mDefaultTabColorizer.setIndicatorColors(colors);
+        invalidate();
+    }
+
+    void onViewPagerPageChanged(int position, float positionOffset) {
+        mSelectedPosition = position;
+        mSelectionOffset = positionOffset;
+        invalidate();
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        final int height = getHeight();
+        final int childCount = getChildCount();
+        final SlidingTabLayout.TabColorizer tabColorizer = mCustomTabColorizer != null
+                ? mCustomTabColorizer
+                : mDefaultTabColorizer;
+
+        // Thick colored underline below the current selection
+        if (childCount > 0) {
+            View selectedTitle = getChildAt(mSelectedPosition);
+            int left = selectedTitle.getLeft();
+            int right = selectedTitle.getRight();
+            int color = tabColorizer.getIndicatorColor(mSelectedPosition);
+
+            if (mSelectionOffset > 0f && mSelectedPosition < (getChildCount() - 1)) {
+                int nextColor = tabColorizer.getIndicatorColor(mSelectedPosition + 1);
+                if (color != nextColor) {
+                    color = blendColors(nextColor, color, mSelectionOffset);
+                }
+
+                // Draw the selection partway between the tabs
+                View nextTitle = getChildAt(mSelectedPosition + 1);
+                left = (int) (mSelectionOffset * nextTitle.getLeft() +
+                        (1.0f - mSelectionOffset) * left);
+                right = (int) (mSelectionOffset * nextTitle.getRight() +
+                        (1.0f - mSelectionOffset) * right);
+            }
+
+            mSelectedIndicatorPaint.setColor(color);
+
+            canvas.drawRect(left, height - mSelectedIndicatorThickness, right,
+                    height, mSelectedIndicatorPaint);
+        }
+
+        // Thin underline along the entire bottom edge
+        canvas.drawRect(0, height - mBottomBorderThickness, getWidth(), height, mBottomBorderPaint);
+    }
+
+    /**
+     * Set the alpha value of the {@code color} to be the given {@code alpha} value.
+     */
+    private static int setColorAlpha(int color, byte alpha) {
+        return Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color));
+    }
+
+    /**
+     * Blend {@code color1} and {@code color2} using the given ratio.
+     *
+     * @param ratio of which to blend. 1.0 will return {@code color1}, 0.5 will give an even blend,
+     *              0.0 will return {@code color2}.
+     */
+    private static int blendColors(int color1, int color2, float ratio) {
+        final float inverseRation = 1f - ratio;
+        float r = (Color.red(color1) * ratio) + (Color.red(color2) * inverseRation);
+        float g = (Color.green(color1) * ratio) + (Color.green(color2) * inverseRation);
+        float b = (Color.blue(color1) * ratio) + (Color.blue(color2) * inverseRation);
+        return Color.rgb((int) r, (int) g, (int) b);
+    }
+
+    private static class SimpleTabColorizer implements SlidingTabLayout.TabColorizer {
+        private int[] mIndicatorColors;
+
+        @Override
+        public final int getIndicatorColor(int position) {
+            return mIndicatorColors[position % mIndicatorColors.length];
+        }
+
+        void setIndicatorColors(int... colors) {
+            mIndicatorColors = colors;
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -14,17 +14,20 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
+-->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
+
     <com.viewpagerindicator.TitlePageIndicator
-            android:id="@+id/titles"
-            android:layout_height="wrap_content"
-            android:layout_width="fill_parent" />
-    <android.support.v4.view.ViewPager android:id="@+id/pager"
-                                       android:layout_height="wrap_content"
-                                       android:layout_width="fill_parent"></android.support.v4.view.ViewPager>
+        android:id="@+id/titles"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"/>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"/>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -21,7 +21,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <com.viewpagerindicator.TitlePageIndicator
+    <org.gdg.frisbee.android.view.SlidingTabLayout
         android:id="@+id/titles"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"/>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -17,17 +17,18 @@
 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <org.gdg.frisbee.android.view.SlidingTabLayout
-        android:id="@+id/titles"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"/>
+  <org.gdg.frisbee.android.view.SlidingTabLayout
+    android:id="@+id/sliding_tabs"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/theme_primary" />
 
-    <android.support.v4.view.ViewPager
-        android:id="@+id/pager"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"/>
+  <android.support.v4.view.ViewPager
+    android:id="@+id/pager"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_arrow.xml
+++ b/app/src/main/res/layout/activity_arrow.xml
@@ -14,96 +14,109 @@
   ~ limitations under the License.
   -->
 
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                        android:orientation="vertical"
-                                        android:id="@+id/drawer"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="match_parent">
+<android.support.v4.widget.DrawerLayout android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-        <ViewFlipper
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:id="@+id/viewFlipper">
+  <ViewFlipper
+    android:id="@+id/viewFlipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-          <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent" android:gravity="center_vertical" android:id="@+id/scanReady"
-                    android:animateLayoutChanges="true"
-              >
-                <ImageView
-                        android:layout_width="match_parent"
-                        android:layout_height="0dp"
-                        android:layout_weight="1"
-                        android:id="@+id/imageView" android:layout_gravity="center" android:src="@drawable/arrow_tagf"
-                        android:scaleType="fitCenter" android:layout_marginTop="10dip"/>
-                <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/arrow_scan"
-                        android:id="@+id/textView" android:padding="30dip" android:gravity="center_vertical|center_horizontal"
-                        android:textStyle="bold"/>
-                <LinearLayout
-                        android:orientation="vertical"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:padding="15dip" android:id="@+id/organizerOnly"
-                        android:visibility="gone">
-                    <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/arrow_organizer"
-                            android:gravity="center_vertical|center_horizontal"
-                            android:id="@+id/textView1"/>
-                    <Button
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/arrow_send_mode"
-                            android:id="@+id/switchToSend" android:layout_gravity="center"/>
-                </LinearLayout>
-            </LinearLayout>
+    <LinearLayout
+      android:id="@+id/scanReady"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:animateLayoutChanges="true"
+      android:gravity="center_vertical"
+      android:orientation="vertical">
 
-          <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical|center_horizontal"
-            android:id="@+id/sendMode">
+      <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:layout_marginTop="10dip"
+        android:layout_weight="1"
+        android:scaleType="fitCenter"
+        android:src="@drawable/arrow_tagf" />
 
-            <ImageView
-              android:layout_width="fill_parent"
-              android:layout_height="0dp"
-              android:scaleType="fitCenter"
-              android:layout_weight="1"
-              android:id="@+id/organizerPic"
-              android:layout_gravity="center" />
+      <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical|center_horizontal"
+        android:padding="30dip"
+        android:text="@string/arrow_scan"
+        android:textStyle="bold" />
 
-            <TextView
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:text="@string/arrow_tag_here"
-              android:id="@+id/textView2"
-              android:padding="30dip"
-              android:gravity="center_vertical|center_horizontal"
-              android:textStyle="bold"
-              android:textAppearance="@android:style/TextAppearance.Large" />
+      <LinearLayout
+        android:id="@+id/organizerOnly"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="15dip"
+        android:visibility="gone">
 
-            <Button
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:text="@string/arrow_back_receive"
-              android:id="@+id/switchToTag"
-              android:layout_marginTop="30dip" />
-          </LinearLayout>
-        </ViewFlipper>
+        <TextView
+          android:id="@+id/textView1"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:gravity="center_vertical|center_horizontal"
+          android:text="@string/arrow_organizer" />
 
-    <ListView
-            android:id="@+id/left_drawer"
-            android:layout_width="240dp"
-            android:layout_height="match_parent"
-            android:layout_gravity="start"
-            android:choiceMode="singleChoice"
-            android:divider="@android:color/transparent"
-            android:dividerHeight="0dp"
-            android:background="#111" />
+        <Button
+          android:id="@+id/switchToSend"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          android:text="@string/arrow_send_mode" />
+      </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+      android:id="@+id/sendMode"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:gravity="center_vertical|center_horizontal"
+      android:orientation="vertical">
+
+      <ImageView
+        android:id="@+id/organizerPic"
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:scaleType="fitCenter" />
+
+      <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical|center_horizontal"
+        android:padding="30dip"
+        android:text="@string/arrow_tag_here"
+        android:textAppearance="@android:style/TextAppearance.Large"
+        android:textStyle="bold" />
+
+      <Button
+        android:id="@+id/switchToTag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30dip"
+        android:text="@string/arrow_back_receive" />
+    </LinearLayout>
+  </ViewFlipper>
+
+  <ListView
+    android:id="@+id/left_drawer"
+    android:layout_width="240dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:background="#111"
+    android:choiceMode="singleChoice"
+    android:divider="@android:color/transparent"
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_arrow_tagged.xml
+++ b/app/src/main/res/layout/activity_arrow_tagged.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +14,29 @@
   ~ limitations under the License.
   -->
 
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                        android:orientation="vertical"
-                                        android:id="@+id/drawer"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="match_parent">
-<LinearLayout
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+<android.support.v4.widget.DrawerLayout android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <ListView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:drawSelectorOnTop="true"
-            android:id="@+id/taggedList"/>
-</LinearLayout>
+      android:id="@+id/taggedList"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:drawSelectorOnTop="true" />
+  </LinearLayout>
 
-    <ListView
-            android:id="@+id/left_drawer"
-            android:layout_width="240dp"
-            android:layout_height="match_parent"
-            android:layout_gravity="start"
-            android:divider="@android:color/transparent"
-            android:dividerHeight="0dp"/>
+  <ListView
+    android:id="@+id/left_drawer"
+    android:layout_width="240dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:divider="@android:color/transparent"
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -14,20 +14,20 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
+-->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
 
-  <com.viewpagerindicator.TitlePageIndicator
-    android:id="@+id/titles"
-    android:layout_height="wrap_content"
-    android:layout_width="fill_parent" />
+    <com.viewpagerindicator.TitlePageIndicator
+        android:id="@+id/titles"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"/>
 
-  <android.support.v4.view.ViewPager
-    android:id="@+id/pager"
-    android:layout_height="wrap_content"
-    android:layout_width="fill_parent"></android.support.v4.view.ViewPager>
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"/>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -21,7 +21,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <com.viewpagerindicator.TitlePageIndicator
+    <org.gdg.frisbee.android.view.SlidingTabLayout
         android:id="@+id/titles"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"/>

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -17,17 +17,18 @@
 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
               android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <org.gdg.frisbee.android.view.SlidingTabLayout
-        android:id="@+id/titles"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"/>
+  <org.gdg.frisbee.android.view.SlidingTabLayout
+    android:id="@+id/sliding_tabs"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/theme_primary" />
 
-    <android.support.v4.view.ViewPager
+  <android.support.v4.view.ViewPager
         android:id="@+id/pager"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"/>
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -17,7 +17,7 @@
 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
+  android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
 
@@ -28,7 +28,7 @@
     android:background="@color/theme_primary" />
 
   <android.support.v4.view.ViewPager
-        android:id="@+id/pager"
+    android:id="@+id/pager"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_first_start.xml
+++ b/app/src/main/res/layout/activity_first_start.xml
@@ -43,3 +43,4 @@
       android:indeterminate="true" />
   </LinearLayout>
 </FrameLayout>
+

--- a/app/src/main/res/layout/activity_first_start.xml
+++ b/app/src/main/res/layout/activity_first_start.xml
@@ -17,21 +17,29 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
-    <org.gdg.frisbee.android.view.NonSwipeableViewPager android:id="@+id/pager"
-                                       android:layout_height="match_parent"
-                                       android:layout_width="match_parent"></org.gdg.frisbee.android.view.NonSwipeableViewPager>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/loading" android:visibility="gone"
-            android:background="@color/light_semi_transparent" android:clickable="true"
-            android:gravity="center_vertical|center_horizontal">
-        <ProgressBar
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/progressBar" android:indeterminate="true"/>
-    </LinearLayout>
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
+
+  <org.gdg.frisbee.android.view.NonSwipeableViewPager
+    android:id="@+id/pager"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"></org.gdg.frisbee.android.view.NonSwipeableViewPager>
+
+  <LinearLayout
+    android:id="@+id/loading"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="@color/light_semi_transparent"
+    android:clickable="true"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical"
+    android:visibility="gone">
+
+    <ProgressBar
+      android:id="@+id/progressBar"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:indeterminate="true" />
+  </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/activity_gde.xml
+++ b/app/src/main/res/layout/activity_gde.xml
@@ -27,7 +27,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.viewpagerindicator.TitlePageIndicator
+        <org.gdg.frisbee.android.view.SlidingTabLayout
             android:id="@+id/titles"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"/>

--- a/app/src/main/res/layout/activity_gde.xml
+++ b/app/src/main/res/layout/activity_gde.xml
@@ -50,4 +50,4 @@
     android:divider="@android:color/transparent"
     android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>
-    
+

--- a/app/src/main/res/layout/activity_gde.xml
+++ b/app/src/main/res/layout/activity_gde.xml
@@ -16,36 +16,38 @@
   ~ limitations under the License.
 -->
 
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                        android:orientation="vertical"
-                                        android:id="@+id/drawer"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="match_parent">
+<android.support.v4.widget.DrawerLayout
+  android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-        <org.gdg.frisbee.android.view.SlidingTabLayout
-            android:id="@+id/titles"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"/>
+    <org.gdg.frisbee.android.view.SlidingTabLayout
+      android:id="@+id/sliding_tabs"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="@color/theme_primary" />
 
-        <android.support.v4.view.ViewPager
-            android:id="@+id/pager"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"/>
-    </LinearLayout>
+    <android.support.v4.view.ViewPager
+      android:id="@+id/pager"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content" />
+  </LinearLayout>
 
-    <ListView
-        android:id="@+id/left_drawer"
-        android:layout_width="240dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:choiceMode="singleChoice"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="0dp"
-        android:background="#111"/>
+  <ListView
+    android:id="@+id/left_drawer"
+    android:layout_width="240dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:background="#111"
+    android:choiceMode="singleChoice"
+    android:divider="@android:color/transparent"
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>
     

--- a/app/src/main/res/layout/activity_gde.xml
+++ b/app/src/main/res/layout/activity_gde.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
   ~ Copyright 2013-2015 The GDG Frisbee Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,37 +14,38 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
+-->
 
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                         android:orientation="vertical"
                                         android:id="@+id/drawer"
-                                        android:layout_width="fill_parent"
-                                        android:layout_height="fill_parent">
+                                        android:layout_width="match_parent"
+                                        android:layout_height="match_parent">
 
     <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
         <com.viewpagerindicator.TitlePageIndicator
-                android:id="@+id/titles"
-                android:layout_height="wrap_content"
-                android:layout_width="fill_parent" />
+            android:id="@+id/titles"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"/>
 
         <android.support.v4.view.ViewPager
-                android:id="@+id/pager"
-                android:layout_height="wrap_content"
-                android:layout_width="fill_parent"></android.support.v4.view.ViewPager>
+            android:id="@+id/pager"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"/>
     </LinearLayout>
 
     <ListView
-            android:id="@+id/left_drawer"
-            android:layout_width="240dp"
-            android:layout_height="match_parent"
-            android:layout_gravity="start"
-            android:choiceMode="singleChoice"
-            android:divider="@android:color/transparent"
-            android:dividerHeight="0dp"
-            android:background="#111" />
+        android:id="@+id/left_drawer"
+        android:layout_width="240dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:choiceMode="singleChoice"
+        android:divider="@android:color/transparent"
+        android:dividerHeight="0dp"
+        android:background="#111"/>
 </android.support.v4.widget.DrawerLayout>
+    

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,35 +17,35 @@
 -->
 
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
-  android:id="@+id/drawer"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+                                        android:orientation="vertical"
+                                        android:id="@+id/drawer"
+                                        android:layout_width="match_parent"
+                                        android:layout_height="match_parent">
 
-  <LinearLayout
-    android:id="@+id/content_frame"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    <LinearLayout
+        android:id="@+id/content_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-    <com.viewpagerindicator.TitlePageIndicator
-      android:id="@+id/titles"
-      android:layout_height="wrap_content"
-      android:layout_width="match_parent" />
+        <com.viewpagerindicator.TitlePageIndicator
+            android:id="@+id/titles"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"/>
 
-    <android.support.v4.view.ViewPager
-      android:id="@+id/pager"
-      android:layout_height="wrap_content"
-      android:layout_width="match_parent" />
-  </LinearLayout>
+        <android.support.v4.view.ViewPager
+            android:id="@+id/pager"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"/>
+    </LinearLayout>
 
-  <ListView
-    android:id="@+id/left_drawer"
-    android:layout_width="240dp"
-    android:layout_height="match_parent"
-    android:layout_gravity="start"
-    android:choiceMode="singleChoice"
-    android:divider="@android:color/transparent"
-    android:dividerHeight="0dp"
-    android:background="#111" />
+    <ListView
+        android:id="@+id/left_drawer"
+        android:layout_width="240dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:choiceMode="singleChoice"
+        android:divider="@android:color/transparent"
+        android:dividerHeight="0dp"
+        android:background="#111"/>
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,7 +28,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <com.viewpagerindicator.TitlePageIndicator
+        <org.gdg.frisbee.android.view.SlidingTabLayout
             android:id="@+id/titles"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"/>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,36 +16,38 @@
   ~ limitations under the License.
 -->
 
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                        android:orientation="vertical"
-                                        android:id="@+id/drawer"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="match_parent">
+<android.support.v4.widget.DrawerLayout
+  android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <LinearLayout
-        android:id="@+id/content_frame"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+  <LinearLayout
+    android:id="@+id/content_frame"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-        <org.gdg.frisbee.android.view.SlidingTabLayout
-            android:id="@+id/titles"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"/>
+    <org.gdg.frisbee.android.view.SlidingTabLayout
+      android:id="@+id/sliding_tabs"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="@color/theme_primary" />
 
-        <android.support.v4.view.ViewPager
-            android:id="@+id/pager"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"/>
-    </LinearLayout>
+    <android.support.v4.view.ViewPager
+      android:id="@+id/pager"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content" />
+  </LinearLayout>
 
-    <ListView
-        android:id="@+id/left_drawer"
-        android:layout_width="240dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:choiceMode="singleChoice"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="0dp"
-        android:background="#111"/>
+  <ListView
+    android:id="@+id/left_drawer"
+    android:layout_width="240dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:background="#111"
+    android:choiceMode="singleChoice"
+    android:divider="@android:color/transparent"
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_pulse.xml
+++ b/app/src/main/res/layout/activity_pulse.xml
@@ -50,4 +50,3 @@
     android:divider="@android:color/transparent"
     android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>
-    

--- a/app/src/main/res/layout/activity_pulse.xml
+++ b/app/src/main/res/layout/activity_pulse.xml
@@ -27,7 +27,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.viewpagerindicator.TitlePageIndicator
+        <org.gdg.frisbee.android.view.SlidingTabLayout
             android:id="@+id/titles"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"/>

--- a/app/src/main/res/layout/activity_pulse.xml
+++ b/app/src/main/res/layout/activity_pulse.xml
@@ -1,34 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!--
+~ Copyright 2013-2015 The GDG Frisbee Project
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ 	http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
-  android:id="@+id/drawer"
-  android:layout_width="fill_parent"
-  android:layout_height="fill_parent">
+                                        android:orientation="vertical"
+                                        android:id="@+id/drawer"
+                                        android:layout_width="match_parent"
+                                        android:layout_height="match_parent">
 
-  <LinearLayout
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <com.viewpagerindicator.TitlePageIndicator
-      android:id="@+id/titles"
-      android:layout_height="wrap_content"
-      android:layout_width="fill_parent" />
+        <com.viewpagerindicator.TitlePageIndicator
+            android:id="@+id/titles"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"/>
 
-    <android.support.v4.view.ViewPager
-      android:id="@+id/pager"
-      android:layout_height="wrap_content"
-      android:layout_width="fill_parent"></android.support.v4.view.ViewPager>
-  </LinearLayout>
+        <android.support.v4.view.ViewPager
+            android:id="@+id/pager"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"/>
+    </LinearLayout>
 
-  <ListView
-    android:id="@+id/left_drawer"
-    android:layout_width="240dp"
-    android:layout_height="match_parent"
-    android:layout_gravity="start"
-    android:choiceMode="singleChoice"
-    android:divider="@android:color/transparent"
-    android:dividerHeight="0dp"
-    android:background="#111" />
+    <ListView
+        android:id="@+id/left_drawer"
+        android:layout_width="240dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:choiceMode="singleChoice"
+        android:divider="@android:color/transparent"
+        android:dividerHeight="0dp"
+        android:background="#111"/>
 </android.support.v4.widget.DrawerLayout>
+    

--- a/app/src/main/res/layout/activity_pulse.xml
+++ b/app/src/main/res/layout/activity_pulse.xml
@@ -16,36 +16,38 @@
 ~ limitations under the License.
 -->
 
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                        android:orientation="vertical"
-                                        android:id="@+id/drawer"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="match_parent">
+<android.support.v4.widget.DrawerLayout
+  android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-        <org.gdg.frisbee.android.view.SlidingTabLayout
-            android:id="@+id/titles"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"/>
+    <org.gdg.frisbee.android.view.SlidingTabLayout
+      android:id="@+id/sliding_tabs"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="@color/theme_primary" />
 
-        <android.support.v4.view.ViewPager
-            android:id="@+id/pager"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"/>
-    </LinearLayout>
+    <android.support.v4.view.ViewPager
+      android:id="@+id/pager"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content" />
+  </LinearLayout>
 
-    <ListView
-        android:id="@+id/left_drawer"
-        android:layout_width="240dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:choiceMode="singleChoice"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="0dp"
-        android:background="#111"/>
+  <ListView
+    android:id="@+id/left_drawer"
+    android:layout_width="240dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:background="#111"
+    android:choiceMode="singleChoice"
+    android:divider="@android:color/transparent"
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>
     

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -13,27 +13,27 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                        android:orientation="vertical"
-                                        android:id="@+id/drawer"
-                                        android:layout_width="fill_parent"
-                                        android:layout_height="fill_parent">
+<android.support.v4.widget.DrawerLayout android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:orientation="vertical">
 
-    <LinearLayout
-            android:id="@+id/content_frame"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
+  <LinearLayout
+    android:id="@+id/content_frame"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    </LinearLayout>
+  </LinearLayout>
 
-    <ListView
-            android:id="@+id/left_drawer"
-            android:layout_width="240dp"
-            android:layout_height="match_parent"
-            android:layout_gravity="start"
-            android:choiceMode="singleChoice"
-            android:divider="@android:color/transparent"
-            android:dividerHeight="0dp"
-            android:background="#111" />
+  <ListView
+    android:id="@+id/left_drawer"
+    android:layout_width="240dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:background="#111"
+    android:choiceMode="singleChoice"
+    android:divider="@android:color/transparent"
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -17,12 +17,12 @@
 -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
   <fragment
+    android:name="org.gdg.frisbee.android.fragment.SettingsFragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:name="org.gdg.frisbee.android.fragment.SettingsFragment" />
+    android:layout_height="match_parent" />
 </FrameLayout>

--- a/app/src/main/res/layout/activity_special.xml
+++ b/app/src/main/res/layout/activity_special.xml
@@ -13,11 +13,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
-  android:id="@+id/drawer"
+<android.support.v4.widget.DrawerLayout android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="fill_parent"
-  android:layout_height="fill_parent">
+  android:layout_height="fill_parent"
+  android:orientation="vertical">
 
   <LinearLayout
     android:id="@+id/content_frame"
@@ -26,23 +26,23 @@
     android:orientation="vertical">
 
     <LinearLayout
-      android:orientation="horizontal"
       android:layout_width="fill_parent"
       android:layout_height="wrap_content"
+      android:orientation="horizontal"
       android:padding="10dip">
 
-      <android.support.v7.widget.CardView
-        xmlns:card_view="http://schemas.android.com/apk/res-auto"
-        card_view:cardCornerRadius="5dp"
+      <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:layout_height="wrap_content">
+        card_view:cardCornerRadius="5dp">
+
         <TextView
+          android:id="@+id/special_description"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:text="@string/special_description"
-          android:id="@+id/special_description"
-          android:padding="10dip" />
+          android:padding="10dip"
+          android:text="@string/special_description" />
       </android.support.v7.widget.CardView>
     </LinearLayout>
 
@@ -59,8 +59,8 @@
     android:layout_width="240dp"
     android:layout_height="match_parent"
     android:layout_gravity="start"
+    android:background="#111"
     android:choiceMode="singleChoice"
     android:divider="@android:color/transparent"
-    android:dividerHeight="0dp"
-    android:background="#111" />
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_youtube.xml
+++ b/app/src/main/res/layout/activity_youtube.xml
@@ -16,14 +16,17 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent" android:gravity="center_vertical|center_horizontal"
-              android:background="@color/semi_transparent" android:id="@+id/videoContainer">
-    <fragment
-            android:name="com.google.android.youtube.player.YouTubePlayerSupportFragment"
-            android:id="@+id/youtube_fragment"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+<LinearLayout android:id="@+id/videoContainer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="@color/semi_transparent"
+  android:gravity="center_vertical|center_horizontal"
+  android:orientation="vertical">
+
+  <fragment
+    android:id="@+id/youtube_fragment"
+    android:name="com.google.android.youtube.player.YouTubePlayerSupportFragment"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/main/res/layout/contributor_item.xml
+++ b/app/src/main/res/layout/contributor_item.xml
@@ -1,30 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content" android:padding="5dip">
-    <android.support.v7.widget.CardView
-        xmlns:card_view="http://schemas.android.com/apk/res-auto"
-        card_view:cardCornerRadius="5dp"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent">
-        <LinearLayout
-                android:orientation="horizontal"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:gravity="center_vertical">
-            <ImageView android:layout_width="45dip"
-                  android:layout_height="45dip"
-                  android:id="@+id/contributorIcon"
-                  android:minHeight="45dip" android:minWidth="45dip" android:scaleType="centerCrop"
-                    />
-            <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="New Text"
-                    android:id="@+id/contributorName" android:layout_marginLeft="10dip" android:autoLink="web"
-                    android:textStyle="bold"/>
-        </LinearLayout>
-    </android.support.v7.widget.CardView>
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content"
+  android:orientation="vertical"
+  android:padding="5dip">
+
+  <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    card_view:cardCornerRadius="5dp">
+
+    <LinearLayout
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:gravity="center_vertical"
+      android:orientation="horizontal">
+
+      <ImageView
+        android:id="@+id/contributorIcon"
+        android:layout_width="45dip"
+        android:layout_height="45dip"
+        android:minHeight="45dip"
+        android:minWidth="45dip"
+        android:scaleType="centerCrop" />
+
+      <TextView
+        android:id="@+id/contributorName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dip"
+        android:autoLink="web"
+        android:text="New Text"
+        android:textStyle="bold" />
+    </LinearLayout>
+  </android.support.v7.widget.CardView>
 </LinearLayout>

--- a/app/src/main/res/layout/empty.xml
+++ b/app/src/main/res/layout/empty.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,37 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:id="@+id/scrollView">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent" android:padding="10dip">
-            <view android:layout_width="wrap_content"
-                  android:layout_height="wrap_content"
-                  class="org.gdg.frisbee.android.view.ResizableImageView" android:id="@+id/view"
-                  android:src="@drawable/gdg_world"/>
-            <ImageView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:id="@+id/imageView" android:src="@drawable/powered_by_x"/>
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/about_license"
-                    android:id="@+id/textView" android:layout_marginTop="10dip" android:gravity="center_horizontal"/>
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:text="1.0"
-                    android:id="@+id/version" android:gravity="center_horizontal" android:layout_marginTop="15dip"
-                    android:textStyle="bold"/>
-        </LinearLayout>
-    </ScrollView>
+  <ScrollView
+    android:id="@+id/scrollView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical"
+      android:padding="10dip">
+
+      <view
+        android:id="@+id/view"
+        class="org.gdg.frisbee.android.view.ResizableImageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/gdg_world" />
+
+      <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:src="@drawable/powered_by_x" />
+
+      <TextView
+        android:id="@+id/textView"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dip"
+        android:gravity="center_horizontal"
+        android:text="@string/about_license" />
+
+      <TextView
+        android:id="@+id/version"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dip"
+        android:gravity="center_horizontal"
+        android:text="1.0"
+        android:textStyle="bold" />
+    </LinearLayout>
+  </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_about_contributors.xml
+++ b/app/src/main/res/layout/fragment_about_contributors.xml
@@ -17,30 +17,36 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <TextView
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/contributors"
-            android:id="@+id/textView" android:padding="10dip"/>
-    <GridView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:drawSelectorOnTop="true"
-            android:numColumns="auto_fit"
-            android:id="@android:id/list" android:stretchMode="columnWidth"
-            android:gravity="top"/>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/loading" android:gravity="center_vertical|center_horizontal">
-    </LinearLayout>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/empty">
-    </LinearLayout>
+  <TextView
+    android:id="@+id/textView"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:padding="10dip"
+    android:text="@string/contributors" />
+
+  <GridView
+    android:id="@android:id/list"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:drawSelectorOnTop="true"
+    android:gravity="top"
+    android:numColumns="auto_fit"
+    android:stretchMode="columnWidth" />
+
+  <LinearLayout
+    android:id="@+id/loading"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical"></LinearLayout>
+
+  <LinearLayout
+    android:id="@+id/empty"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical"></LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_changelog.xml
+++ b/app/src/main/res/layout/fragment_changelog.xml
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <ScrollView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/scrollView" android:layout_gravity="center">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent">
-            <android.support.v7.widget.CardView
-                xmlns:card_view="http://schemas.android.com/apk/res-auto"
-                card_view:cardCornerRadius="5dp"
-                android:layout_margin="10dip"
-                android:padding="10dip"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent">
-                <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="New Text"
-                        android:id="@+id/changelog"/>
-            </android.support.v7.widget.CardView>
-        </LinearLayout>
-    </ScrollView>
+  <ScrollView
+    android:id="@+id/scrollView"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_gravity="center">
+
+    <LinearLayout
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical">
+
+      <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_margin="10dip"
+        android:padding="10dip"
+        card_view:cardCornerRadius="5dp">
+
+        <TextView
+          android:id="@+id/changelog"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="New Text" />
+      </android.support.v7.widget.CardView>
+    </LinearLayout>
+  </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_chapter_info.xml
+++ b/app/src/main/res/layout/fragment_chapter_info.xml
@@ -15,92 +15,120 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<LinearLayout android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical">
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <LinearLayout android:orientation="vertical" android:layout_width="fill_parent" android:layout_height="fill_parent"
-                  android:id="@+id/loading" android:gravity="center_vertical|center_horizontal">
-        <org.gdg.frisbee.android.view.AnimationImageView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/imageView" android:src="@drawable/gdg_load"/>
-    </LinearLayout>
-    <ScrollView android:layout_width="match_parent"
-              android:layout_height="match_parent" android:id="@+id/container">
+  <LinearLayout
+    android:id="@+id/loading"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
+
+    <org.gdg.frisbee.android.view.AnimationImageView
+      android:id="@+id/imageView"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:src="@drawable/gdg_load" />
+  </LinearLayout>
+
+  <ScrollView
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/scrollView" android:orientation="vertical" android:paddingLeft="10dip"
-            android:paddingRight="10dip" android:paddingTop="5dip" android:paddingBottom="5dip">
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/about"
-                android:id="@+id/tagline" android:textStyle="bold"
-                android:textAppearance="@android:style/TextAppearance.Medium" android:layout_marginLeft="5dip"/>
-        <android.support.v7.widget.CardView
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
-            card_view:cardCornerRadius="5dp"
-            android:padding="8dip"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" android:layout_gravity="center"
-                    android:id="@+id/about_box"
-                    android:layout_marginBottom="10dip">
-                <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:id="@+id/about" android:autoLink="email|map|web"/>
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/organizers"
-                android:layout_marginTop="15dip"
-                android:id="@+id/textView" android:textStyle="bold"
-                android:textAppearance="@android:style/TextAppearance.Medium" android:layout_marginLeft="5dip"/>
-        <android.support.v7.widget.CardView
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
-            card_view:cardCornerRadius="5dp"
-            android:padding="8dip"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
-            <LinearLayout android:orientation="vertical" android:layout_width="fill_parent"
-                          android:layout_height="fill_parent" android:layout_gravity="center"
-                          android:id="@+id/organizer_box" android:layout_marginBottom="10dip">
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
+      android:id="@+id/scrollView"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical"
+      android:paddingBottom="5dip"
+      android:paddingLeft="10dip"
+      android:paddingRight="10dip"
+      android:paddingTop="5dip">
 
-        <TextView
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/resources"
-          android:id="@+id/textView2"
-          android:layout_marginTop="15dip"
-          android:textStyle="bold"
-          android:textAppearance="@android:style/TextAppearance.Medium"
-          android:layout_marginLeft="5dip" />
+      <TextView
+        android:id="@+id/tagline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="5dip"
+        android:text="@string/about"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        android:textStyle="bold" />
 
-        <android.support.v7.widget.CardView
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
-            card_view:cardCornerRadius="5dp"
-            android:padding="8dip"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
+      <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:padding="8dip"
+        card_view:cardCornerRadius="5dp">
+
         <LinearLayout
-          android:orientation="vertical"
+          android:id="@+id/about_box"
           android:layout_width="fill_parent"
           android:layout_height="fill_parent"
           android:layout_gravity="center"
-          android:id="@+id/resources_box"/>
-        </android.support.v7.widget.CardView>
+          android:layout_marginBottom="10dip"
+          android:orientation="vertical">
+
+          <TextView
+            android:id="@+id/about"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autoLink="email|map|web" />
+        </LinearLayout>
+      </android.support.v7.widget.CardView>
+
+      <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="5dip"
+        android:layout_marginTop="15dip"
+        android:text="@string/organizers"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        android:textStyle="bold" />
+
+      <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:padding="8dip"
+        card_view:cardCornerRadius="5dp">
+
+        <LinearLayout
+          android:id="@+id/organizer_box"
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:layout_gravity="center"
+          android:layout_marginBottom="10dip"
+          android:orientation="vertical"></LinearLayout>
+      </android.support.v7.widget.CardView>
+
+      <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="5dip"
+        android:layout_marginTop="15dip"
+        android:text="@string/resources"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        android:textStyle="bold" />
+
+      <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:padding="8dip"
+        card_view:cardCornerRadius="5dp">
+
+        <LinearLayout
+          android:id="@+id/resources_box"
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:layout_gravity="center"
+          android:orientation="vertical" />
+      </android.support.v7.widget.CardView>
     </LinearLayout>
-</ScrollView>
+  </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_event_overview.xml
+++ b/app/src/main/res/layout/fragment_event_overview.xml
@@ -2,105 +2,105 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  android:orientation="vertical"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
   <LinearLayout
-    android:orientation="vertical"
+    android:id="@+id/loading"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:id="@+id/loading"
-    android:gravity="center_vertical|center_horizontal">
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
 
     <org.gdg.frisbee.android.view.AnimationImageView
+      android:id="@+id/imageView"
       android:layout_width="fill_parent"
       android:layout_height="wrap_content"
-      android:id="@+id/imageView"
       android:src="@drawable/gdg_load" />
   </LinearLayout>
 
   <ScrollView
+    android:id="@+id/scrollView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:id="@+id/scrollView">
+    android:layout_height="match_parent">
 
     <RelativeLayout
-      android:orientation="vertical"
       android:layout_width="fill_parent"
       android:layout_height="fill_parent"
+      android:orientation="vertical"
       android:padding="10dip">
 
       <ImageView
+        android:id="@+id/group_logo"
         android:layout_width="@dimen/logo_size"
         android:layout_height="@dimen/logo_size"
-        android:id="@+id/group_logo"
-        android:scaleType="fitCenter"
-        android:src="@drawable/icon"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true"
-        android:layout_margin="8dip" />
+        android:layout_alignParentRight="true"
+        android:layout_alignParentTop="true"
+        android:layout_margin="8dip"
+        android:scaleType="fitCenter"
+        android:src="@drawable/icon" />
 
       <TextView
+        android:id="@+id/date"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        tools:text="March 14, 2014"
-        android:id="@+id/date"
-        android:gravity="center_horizontal"
-        android:textStyle="bold"
         android:layout_alignParentTop="true"
         android:layout_marginTop="16dip"
-        android:layout_toLeftOf="@+id/group_logo" />
+        android:layout_toLeftOf="@+id/group_logo"
+        android:gravity="center_horizontal"
+        android:textStyle="bold"
+        tools:text="March 14, 2014" />
 
       <TextView
+        android:id="@+id/title"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        tools:text="Event Title"
-        android:id="@+id/title"
-        android:gravity="center_horizontal"
-        android:textAppearance="?android:textAppearanceLarge"
         android:layout_below="@+id/date"
         android:layout_margin="16dip"
-        android:layout_toLeftOf="@+id/group_logo" />
+        android:layout_toLeftOf="@+id/group_logo"
+        android:gravity="center_horizontal"
+        android:textAppearance="?android:textAppearanceLarge"
+        tools:text="Event Title" />
 
       <TextView
+        android:id="@+id/start_time"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        tools:text="Begin 20:15"
-        android:id="@+id/start_time"
-        android:gravity="start"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:layout_below="@+id/title"
         android:layout_marginLeft="16dip"
-        android:layout_marginRight="16dip" />
+        android:layout_marginRight="16dip"
+        android:gravity="start"
+        tools:text="Begin 20:15" />
 
       <TextView
+        android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/event_description"
-        android:id="@+id/textView"
-        android:textStyle="bold"
-        android:textAppearance="@android:style/TextAppearance.Medium"
-        android:layout_below="@+id/start_time"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:layout_marginLeft="16dip" />
+        android:layout_below="@+id/start_time"
+        android:layout_marginLeft="16dip"
+        android:text="@string/event_description"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        android:textStyle="bold" />
 
       <LinearLayout
-        android:orientation="vertical"
+        android:id="@+id/event_description_container"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        android:layout_gravity="center"
-        android:background="@drawable/resources_box"
-        android:padding="8dip"
-        android:id="@+id/event_description_container"
-        android:layout_below="@+id/textView"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
+        android:layout_below="@+id/textView"
+        android:layout_gravity="center"
         android:layout_marginLeft="8dip"
-        android:layout_marginRight="8dip">
+        android:layout_marginRight="8dip"
+        android:background="@drawable/resources_box"
+        android:orientation="vertical"
+        android:padding="8dip">
 
         <TextView
           android:id="@+id/event_description"

--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -17,43 +17,57 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <ListView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:drawSelectorOnTop="true"
-            android:id="@android:id/list"/>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/loading" android:gravity="center_vertical|center_horizontal">
-        <org.gdg.frisbee.android.view.AnimationImageView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/imageView" android:src="@drawable/gdg_load"/>
-    </LinearLayout>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/empty" android:gravity="center_vertical|center_horizontal">
+  <ListView
+    android:id="@android:id/list"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:drawSelectorOnTop="true" />
 
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" android:gravity="center_vertical|center_horizontal">
-            <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:id="@+id/imageView1" android:src="@drawable/no_events"/>
-            <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/no_scheduled_events"
-                    android:id="@+id/textView" android:layout_marginTop="15dip" android:layout_gravity="left"
-                    android:singleLine="true"/>
-        </LinearLayout>
+  <LinearLayout
+    android:id="@+id/loading"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
+
+    <org.gdg.frisbee.android.view.AnimationImageView
+      android:id="@+id/imageView"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:src="@drawable/gdg_load" />
+  </LinearLayout>
+
+  <LinearLayout
+    android:id="@+id/empty"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
+
+    <LinearLayout
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:gravity="center_vertical|center_horizontal"
+      android:orientation="vertical">
+
+      <ImageView
+        android:id="@+id/imageView1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/no_events" />
+
+      <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:layout_marginTop="15dip"
+        android:singleLine="true"
+        android:text="@string/no_scheduled_events" />
     </LinearLayout>
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_external_libraries.xml
+++ b/app/src/main/res/layout/fragment_external_libraries.xml
@@ -1,29 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <ScrollView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/scrollView" android:layout_gravity="center">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent">
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" android:padding="10dip" android:background="@drawable/card_bg"
-                    android:layout_margin="10dip">
-                <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="New Text"
-                        android:id="@+id/external" android:autoLink="web"/>
-            </LinearLayout>
-        </LinearLayout>
-    </ScrollView>
+  <ScrollView
+    android:id="@+id/scrollView"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_gravity="center">
+
+    <LinearLayout
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical">
+
+      <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_margin="10dip"
+        android:background="@drawable/card_bg"
+        android:orientation="vertical"
+        android:padding="10dip">
+
+        <TextView
+          android:id="@+id/external"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:autoLink="web"
+          android:text="New Text" />
+      </LinearLayout>
+    </LinearLayout>
+  </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_gde_about.xml
+++ b/app/src/main/res/layout/fragment_gde_about.xml
@@ -1,63 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-    <LinearLayout
-                  android:orientation="vertical"
-                  android:layout_width="match_parent"
-                  android:layout_height="wrap_content" android:paddingLeft="8dip" android:paddingRight="8dip"
-                  android:paddingTop="8dip">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
 
-        <android.support.v7.widget.CardView
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
-            card_view:cardCornerRadius="5dp"
-            android:layout_marginBottom="15dip"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" android:padding="10dip">
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingLeft="8dip"
+    android:paddingRight="8dip"
+    android:paddingTop="8dip">
 
-                <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:text="@string/gde_who_title"
-                        android:id="@+id/textView" android:textStyle="bold" android:paddingBottom="10dip"/>
-                <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/gde_who_desc"
-                        android:id="@+id/textView2"/>
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
+    <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="15dip"
+      card_view:cardCornerRadius="5dp">
 
-        <android.support.v7.widget.CardView
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
-            card_view:cardCornerRadius="5dp"
-            android:layout_marginBottom="8dip"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" android:padding="10dip">
+      <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:orientation="vertical"
+        android:padding="10dip">
 
-                <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:text="@string/gde_what_title"
-                        android:id="@+id/textView3" android:textStyle="bold" android:paddingBottom="10dip"/>
-                <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/gde_what_desc"
-                        android:id="@+id/textView4"/>
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-    </LinearLayout>
+        <TextView
+          android:id="@+id/textView"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:paddingBottom="10dip"
+          android:text="@string/gde_who_title"
+          android:textAppearance="?android:attr/textAppearanceMedium"
+          android:textStyle="bold" />
+
+        <TextView
+          android:id="@+id/textView2"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/gde_who_desc" />
+      </LinearLayout>
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="8dip"
+      card_view:cardCornerRadius="5dp">
+
+      <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:orientation="vertical"
+        android:padding="10dip">
+
+        <TextView
+          android:id="@+id/textView3"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:paddingBottom="10dip"
+          android:text="@string/gde_what_title"
+          android:textAppearance="?android:attr/textAppearanceMedium"
+          android:textStyle="bold" />
+
+        <TextView
+          android:id="@+id/textView4"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/gde_what_desc" />
+      </LinearLayout>
+    </android.support.v7.widget.CardView>
+  </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_gde_list.xml
+++ b/app/src/main/res/layout/fragment_gde_list.xml
@@ -17,36 +17,36 @@
 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
   <GridView
+    android:id="@android:id/list"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:gravity="top"
     android:numColumns="auto_fit"
-    android:id="@android:id/list"
-    android:stretchMode="columnWidth"
-    android:gravity="top" />
+    android:stretchMode="columnWidth" />
 
   <LinearLayout
-    android:orientation="vertical"
+    android:id="@+id/loading"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/loading"
-    android:gravity="center_vertical|center_horizontal">
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
 
     <org.gdg.frisbee.android.view.AnimationImageView
+      android:id="@+id/imageView"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:id="@+id/imageView"
       android:src="@drawable/gdg_load" />
   </LinearLayout>
 
   <LinearLayout
-    android:orientation="vertical"
+    android:id="@+id/empty"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/empty"></LinearLayout>
+    android:orientation="vertical"></LinearLayout>
 </LinearLayout>
   

--- a/app/src/main/res/layout/fragment_get_involved.xml
+++ b/app/src/main/res/layout/fragment_get_involved.xml
@@ -1,56 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
 
-    <ScrollView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/scrollView">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent">
-            <android.support.v7.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:card_view="http://schemas.android.com/apk/res-auto"
-                card_view:cardCornerRadius="5dp"
-                android:padding="10dip"
-                android:layout_marginLeft="10dip" android:layout_marginTop="50dip"
-                android:layout_marginRight="10dip" android:layout_marginBottom="10dip"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-                <LinearLayout
-                        android:orientation="vertical"
-                        android:layout_width="fill_parent"
-                        android:layout_height="fill_parent">
-                    <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/get_involved"
-                            android:id="@+id/textView" android:textStyle="bold"/>
-                    <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/get_involved_text"
-                            android:id="@+id/textView1" android:layout_marginTop="10dip" android:autoLink="all"/>
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/get_involved_translation_text"
-                        android:id="@+id/textView2" android:layout_marginTop="10dip" android:autoLink="all"/>
-                </LinearLayout>
-            </android.support.v7.widget.CardView>
-        </LinearLayout>
-    </ScrollView>
+  <ScrollView
+    android:id="@+id/scrollView"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
+
     <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:gravity="right">
-        <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/forkMe" android:src="@drawable/forkme_right"/>
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical">
+
+      <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dip"
+        android:layout_marginLeft="10dip"
+        android:layout_marginRight="10dip"
+        android:layout_marginTop="50dip"
+        android:padding="10dip"
+        card_view:cardCornerRadius="5dp">
+
+        <LinearLayout
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:orientation="vertical">
+
+          <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/get_involved"
+            android:textStyle="bold" />
+
+          <TextView
+            android:id="@+id/textView1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dip"
+            android:autoLink="all"
+            android:text="@string/get_involved_text" />
+
+          <TextView
+            android:id="@+id/textView2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dip"
+            android:autoLink="all"
+            android:text="@string/get_involved_translation_text" />
+        </LinearLayout>
+      </android.support.v7.widget.CardView>
     </LinearLayout>
+  </ScrollView>
+
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="right"
+    android:orientation="vertical">
+
+    <ImageView
+      android:id="@+id/forkMe"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:src="@drawable/forkme_right" />
+  </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_list.xml
+++ b/app/src/main/res/layout/fragment_list.xml
@@ -17,32 +17,41 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <ListView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:drawSelectorOnTop="true"
-            android:id="@android:id/list"/>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/loading" android:gravity="center_vertical|center_horizontal">
-        <ProgressBar
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/progressBar" android:indeterminate="true"/>
-    </LinearLayout>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/empty">
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="New Text"
-                android:id="@+id/textView" android:layout_gravity="center"/>
-    </LinearLayout>
+  <ListView
+    android:id="@android:id/list"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:drawSelectorOnTop="true" />
+
+  <LinearLayout
+    android:id="@+id/loading"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
+
+    <ProgressBar
+      android:id="@+id/progressBar"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:indeterminate="true" />
+  </LinearLayout>
+
+  <LinearLayout
+    android:id="@+id/empty"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+
+    <TextView
+      android:id="@+id/textView"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:text="New Text" />
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -17,9 +17,9 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
   <android.support.v4.widget.SwipeRefreshLayout
     android:id="@+id/news_fragment_swipe_refresh_layout"
@@ -27,30 +27,30 @@
     android:layout_height="match_parent">
 
     <ListView
+      android:id="@android:id/list"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:drawSelectorOnTop="true"
-      android:id="@android:id/list" />
+      android:drawSelectorOnTop="true" />
 
   </android.support.v4.widget.SwipeRefreshLayout>
 
   <LinearLayout
-    android:orientation="vertical"
+    android:id="@+id/loading"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/loading"
-    android:gravity="center_vertical|center_horizontal">
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
 
     <org.gdg.frisbee.android.view.AnimationImageView
+      android:id="@+id/imageView"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:id="@+id/imageView"
       android:src="@drawable/gdg_load" />
   </LinearLayout>
 
   <LinearLayout
-    android:orientation="vertical"
+    android:id="@+id/empty"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/empty" />
+    android:orientation="vertical" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_pulse.xml
+++ b/app/src/main/res/layout/fragment_pulse.xml
@@ -17,28 +17,34 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <ListView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:drawSelectorOnTop="true"
-            android:id="@android:id/list"
-        />
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/loading" android:gravity="center_vertical|center_horizontal">
-        <org.gdg.frisbee.android.view.AnimationImageView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/imageView" android:src="@drawable/gdg_load"/>
-    </LinearLayout>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:id="@+id/empty" android:gravity="center_vertical|center_horizontal">
-    </LinearLayout>
+  <ListView
+    android:id="@android:id/list"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:drawSelectorOnTop="true" />
+
+  <LinearLayout
+    android:id="@+id/loading"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
+
+    <org.gdg.frisbee.android.view.AnimationImageView
+      android:id="@+id/imageView"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:src="@drawable/gdg_load" />
+  </LinearLayout>
+
+  <LinearLayout
+    android:id="@+id/empty"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical"></LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_seasons_greetings.xml
+++ b/app/src/main/res/layout/fragment_seasons_greetings.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content" android:gravity="fill_horizontal|fill_vertical">
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content"
+  android:gravity="fill_horizontal|fill_vertical">
 
-    <ImageView
-               android:layout_width="fill_parent"
-               android:adjustViewBounds="true"
-               android:layout_height="fill_parent" android:src="@drawable/seasons_greetings"
-               android:scaleType="fitXY"/>
+  <ImageView
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:adjustViewBounds="true"
+    android:scaleType="fitXY"
+    android:src="@drawable/seasons_greetings" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_welcome_step1.xml
+++ b/app/src/main/res/layout/fragment_welcome_step1.xml
@@ -1,65 +1,103 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent" android:background="@color/cloud">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="@color/cloud"
+  android:orientation="vertical">
+
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_weight="1"
+    android:gravity="center_vertical"
+    android:orientation="vertical">
 
     <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:layout_weight="1" android:gravity="center_vertical">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" android:layout_marginBottom="25dip"
-                android:paddingLeft="15dip" android:paddingTop="5dip" android:paddingRight="5dip"
-                android:paddingBottom="5dip">
-            <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/welcome"
-                    android:id="@+id/textView" android:singleLine="true"
-                    android:linksClickable="false" android:textSize="24dip" android:textIsSelectable="false"
-                    android:textColor="@color/asbestos"/>
-            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
-                      android:text="@string/choose_home_gdg" android:id="@+id/textView1" android:singleLine="true"
-                      android:linksClickable="false" android:textSize="24dip" android:textIsSelectable="false"
-                      android:textColor="@color/asbestos"/>
-        </LinearLayout>
-        <org.gdg.frisbee.android.view.ResizableImageView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/imageView" android:background="@drawable/gdg_world"
-                android:adjustViewBounds="true"/>
-        <ViewSwitcher
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/viewSwitcher" android:inAnimation="@anim/fade_in" android:outAnimation="@anim/fade_out" android:layout_marginTop="15dip">
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" android:gravity="center_horizontal">
-                <ProgressBar
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:id="@+id/progressBar" android:indeterminate="true" android:indeterminateOnly="true"/>
-            </LinearLayout>
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content" android:gravity="center_horizontal">
-                <Spinner
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:id="@+id/chapter_spinner"/>
-                <Button android:layout_width="wrap_content" android:layout_height="wrap_content"
-                        android:text="@string/confirm" android:id="@+id/confirm"/>
-            </LinearLayout>
-        </ViewSwitcher>
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="25dip"
+      android:orientation="vertical"
+      android:paddingBottom="5dip"
+      android:paddingLeft="15dip"
+      android:paddingRight="5dip"
+      android:paddingTop="5dip">
+
+      <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:linksClickable="false"
+        android:singleLine="true"
+        android:text="@string/welcome"
+        android:textColor="@color/asbestos"
+        android:textIsSelectable="false"
+        android:textSize="24dip" />
+
+      <TextView
+        android:id="@+id/textView1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:linksClickable="false"
+        android:singleLine="true"
+        android:text="@string/choose_home_gdg"
+        android:textColor="@color/asbestos"
+        android:textIsSelectable="false"
+        android:textSize="24dip" />
     </LinearLayout>
-    <ImageView
-            android:layout_width="fill_parent"
-            android:layout_height="15dip"
-            android:id="@+id/imageView1" android:background="@drawable/googly_bar"/>
+
+    <org.gdg.frisbee.android.view.ResizableImageView
+      android:id="@+id/imageView"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:adjustViewBounds="true"
+      android:background="@drawable/gdg_world" />
+
+    <ViewSwitcher
+      android:id="@+id/viewSwitcher"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="15dip"
+      android:inAnimation="@anim/fade_in"
+      android:outAnimation="@anim/fade_out">
+
+      <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <ProgressBar
+          android:id="@+id/progressBar"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:indeterminate="true"
+          android:indeterminateOnly="true" />
+      </LinearLayout>
+
+      <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <Spinner
+          android:id="@+id/chapter_spinner"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content" />
+
+        <Button
+          android:id="@+id/confirm"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/confirm" />
+      </LinearLayout>
+    </ViewSwitcher>
+  </LinearLayout>
+
+  <ImageView
+    android:id="@+id/imageView1"
+    android:layout_width="fill_parent"
+    android:layout_height="15dip"
+    android:background="@drawable/googly_bar" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_welcome_step2.xml
+++ b/app/src/main/res/layout/fragment_welcome_step2.xml
@@ -1,37 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="fill_parent" android:background="@color/cloud">
+  android:layout_width="match_parent"
+  android:layout_height="fill_parent"
+  android:background="@color/cloud"
+  android:orientation="vertical">
 
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:layout_weight="1" android:gravity="center_vertical|center_horizontal"
-            android:padding="50dip">
-        <TextView android:layout_width="fill_parent" android:layout_height="wrap_content"
-                  android:text="@string/signin_description" android:id="@+id/textView" android:singleLine="false"
-                  android:linksClickable="false" android:textIsSelectable="false"
-                  android:textColor="@color/asbestos" android:textAppearance="@android:style/TextAppearance.Large"
-                  android:gravity="center_horizontal" android:layout_marginBottom="20dip"/>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/signin_with_google"
-                android:id="@+id/googleSignin" android:layout_gravity="center" android:background="@drawable/btn_g_signin"
-                style="@style/GoogleSignIn" android:layout_marginBottom="15dip"/>
-        <TextView android:layout_width="fill_parent" android:layout_height="wrap_content"
-                  android:text="@string/or" android:id="@+id/textView1" android:singleLine="false"
-                  android:linksClickable="false" android:textIsSelectable="false" android:textColor="@color/asbestos"
-                  android:textAppearance="@android:style/TextAppearance.Large" android:gravity="center_horizontal"
-                  android:layout_marginBottom="15dip" android:phoneNumber="false" android:autoText="false"/>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/skip"
-                android:id="@+id/skipSignin"/>
-    </LinearLayout>
-    <ImageView android:layout_width="fill_parent" android:layout_height="15dip" android:id="@+id/imageView"
-               android:background="@drawable/googly_bar"/>
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_weight="1"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical"
+    android:padding="50dip">
+
+    <TextView
+      android:id="@+id/textView"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="20dip"
+      android:gravity="center_horizontal"
+      android:linksClickable="false"
+      android:singleLine="false"
+      android:text="@string/signin_description"
+      android:textAppearance="@android:style/TextAppearance.Large"
+      android:textColor="@color/asbestos"
+      android:textIsSelectable="false" />
+
+    <Button
+      android:id="@+id/googleSignin"
+      style="@style/GoogleSignIn"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:layout_marginBottom="15dip"
+      android:background="@drawable/btn_g_signin"
+      android:text="@string/signin_with_google" />
+
+    <TextView
+      android:id="@+id/textView1"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="15dip"
+      android:autoText="false"
+      android:gravity="center_horizontal"
+      android:linksClickable="false"
+      android:phoneNumber="false"
+      android:singleLine="false"
+      android:text="@string/or"
+      android:textAppearance="@android:style/TextAppearance.Large"
+      android:textColor="@color/asbestos"
+      android:textIsSelectable="false" />
+
+    <Button
+      android:id="@+id/skipSignin"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/skip" />
+  </LinearLayout>
+
+  <ImageView
+    android:id="@+id/imageView"
+    android:layout_width="fill_parent"
+    android:layout_height="15dip"
+    android:background="@drawable/googly_bar" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_welcome_step3.xml
+++ b/app/src/main/res/layout/fragment_welcome_step3.xml
@@ -1,58 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="fill_parent" android:background="@color/cloud">
+  android:layout_width="match_parent"
+  android:layout_height="fill_parent"
+  android:background="@color/cloud"
+  android:orientation="vertical">
+
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_weight="1"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical"
+    android:padding="50dip">
 
     <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:layout_weight="1" android:gravity="center_vertical|center_horizontal"
-            android:padding="50dip">
-        <LinearLayout
-                android:orientation="horizontal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
-            <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:id="@+id/imageView1" android:src="@drawable/ic_analytics"
-                    android:layout_marginRight="10dip"/>
-            <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:id="@+id/imageView2" android:src="@drawable/ic_gcm"/>
-        </LinearLayout>
-        <TextView android:layout_width="fill_parent" android:layout_height="wrap_content"
-                  android:text="@string/step3_text" android:id="@+id/textView" android:singleLine="false"
-                  android:linksClickable="false" android:textIsSelectable="false"
-                  android:textColor="@color/asbestos" android:textAppearance="@android:style/TextAppearance.Large"
-                  android:gravity="center_horizontal" android:layout_marginBottom="20dip"/>
-        <LinearLayout
-                android:orientation="horizontal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" android:id="@+id/analyticsContainer">
-            <CheckBox
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:text="@string/allow_analytics"
-                    android:id="@+id/enable_analytics" android:textColor="@color/asbestos" android:textSize="18sp"
-                    android:checked="true"/>
-        </LinearLayout>
-        <LinearLayout android:orientation="horizontal" android:layout_width="wrap_content"
-                      android:layout_height="wrap_content" android:id="@+id/gcmContainer"
-                      android:layout_marginTop="10dip">
-            <CheckBox android:layout_width="wrap_content" android:layout_height="fill_parent"
-                      android:text="@string/enable_gcm" android:id="@+id/enable_gcm" android:textColor="@color/asbestos"
-                      android:textSize="18sp" android:checked="true"/>
-        </LinearLayout>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/done"
-                android:id="@+id/complete" android:layout_marginTop="25dip"/>
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+      <ImageView
+        android:id="@+id/imageView1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="10dip"
+        android:src="@drawable/ic_analytics" />
+
+      <ImageView
+        android:id="@+id/imageView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_gcm" />
     </LinearLayout>
-    <ImageView android:layout_width="fill_parent" android:layout_height="15dip" android:id="@+id/imageView"
-               android:background="@drawable/googly_bar"/>
+
+    <TextView
+      android:id="@+id/textView"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="20dip"
+      android:gravity="center_horizontal"
+      android:linksClickable="false"
+      android:singleLine="false"
+      android:text="@string/step3_text"
+      android:textAppearance="@android:style/TextAppearance.Large"
+      android:textColor="@color/asbestos"
+      android:textIsSelectable="false" />
+
+    <LinearLayout
+      android:id="@+id/analyticsContainer"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+      <CheckBox
+        android:id="@+id/enable_analytics"
+        android:layout_width="wrap_content"
+        android:layout_height="fill_parent"
+        android:checked="true"
+        android:text="@string/allow_analytics"
+        android:textColor="@color/asbestos"
+        android:textSize="18sp" />
+    </LinearLayout>
+
+    <LinearLayout
+      android:id="@+id/gcmContainer"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="10dip"
+      android:orientation="horizontal">
+
+      <CheckBox
+        android:id="@+id/enable_gcm"
+        android:layout_width="wrap_content"
+        android:layout_height="fill_parent"
+        android:checked="true"
+        android:text="@string/enable_gcm"
+        android:textColor="@color/asbestos"
+        android:textSize="18sp" />
+    </LinearLayout>
+
+    <Button
+      android:id="@+id/complete"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="25dip"
+      android:text="@string/done" />
+  </LinearLayout>
+
+  <ImageView
+    android:id="@+id/imageView"
+    android:layout_width="fill_parent"
+    android:layout_height="15dip"
+    android:background="@drawable/googly_bar" />
 </LinearLayout>

--- a/app/src/main/res/layout/gde_item.xml
+++ b/app/src/main/res/layout/gde_item.xml
@@ -1,46 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent" android:baselineAligned="false"
-        >
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:baselineAligned="false"
+  android:orientation="vertical">
 
-    <android.support.v7.widget.CardView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:card_view="http://schemas.android.com/apk/res-auto"
-        card_view:cardCornerRadius="5dp"
-        android:layout_margin="5dip"
-        android:layout_width="match_parent"
+  <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="5dip"
+    card_view:cardCornerRadius="5dp">
+
+    <LinearLayout
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <FrameLayout
+        android:layout_width="fill_parent"
         android:layout_height="wrap_content">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
-            <FrameLayout
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content">
-                <org.gdg.frisbee.android.view.SquaredImageView android:layout_width="match_parent"
 
-                                                                 android:layout_height="wrap_content" android:id="@+id/thumb"
-                        />
-            </FrameLayout>
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" android:padding="5dip">
-                <TextView
-                        android:layout_width="fill_parent"
-                        android:layout_height="wrap_content"
-                        android:text="New Text"
-                        android:textStyle="bold"
-                        android:id="@+id/name" android:maxLines="1" android:ellipsize="end"/>
-                <TextView
-                        android:layout_width="fill_parent"
-                        android:layout_height="wrap_content"
-                        android:text="New Text"
-                        android:id="@+id/country" android:maxLines="1" android:ellipsize="end"/>
-            </LinearLayout>
-        </LinearLayout>
-    </android.support.v7.widget.CardView>
+        <org.gdg.frisbee.android.view.SquaredImageView
+          android:id="@+id/thumb"
+
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content" />
+      </FrameLayout>
+
+      <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:orientation="vertical"
+        android:padding="5dip">
+
+        <TextView
+          android:id="@+id/name"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:ellipsize="end"
+          android:maxLines="1"
+          android:text="New Text"
+          android:textStyle="bold" />
+
+        <TextView
+          android:id="@+id/country"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:ellipsize="end"
+          android:maxLines="1"
+          android:text="New Text" />
+      </LinearLayout>
+    </LinearLayout>
+  </android.support.v7.widget.CardView>
 </LinearLayout>

--- a/app/src/main/res/layout/list_drawer_item.xml
+++ b/app/src/main/res/layout/list_drawer_item.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="horizontal"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content" android:padding="5dip" android:gravity="center_vertical">
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:gravity="center_vertical"
+  android:orientation="horizontal"
+  android:padding="5dip">
 
-    <ImageView
-            android:layout_width="45dip"
-            android:layout_height="45dip"
-            android:id="@+id/icon" android:layout_marginRight="10dip"/>
-    <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="New Text"
-            android:id="@+id/title" android:textColor="@color/white"
-            android:textAppearance="?android:attr/textAppearanceMedium"/>
+  <ImageView
+    android:id="@+id/icon"
+    android:layout_width="45dip"
+    android:layout_height="45dip"
+    android:layout_marginRight="10dip" />
+
+  <TextView
+    android:id="@+id/title"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="New Text"
+    android:textAppearance="?android:attr/textAppearanceMedium"
+    android:textColor="@color/white" />
 </LinearLayout>

--- a/app/src/main/res/layout/list_event_item.xml
+++ b/app/src/main/res/layout/list_event_item.xml
@@ -16,65 +16,81 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:layout_height="wrap_content"
-              android:layout_width="fill_parent" android:paddingLeft="10dip" android:paddingTop="5dip"
-              android:paddingRight="10dip" android:paddingBottom="5dip">
-    <android.support.v7.widget.CardView
-        xmlns:card_view="http://schemas.android.com/apk/res-auto"
-        card_view:cardCornerRadius="5dp"
-        android:padding="8dip"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-        <RelativeLayout
-                      android:orientation="horizontal"
-                      android:layout_width="fill_parent"
-                      android:layout_height="wrap_content">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="wrap_content"
+  android:paddingBottom="5dip"
+  android:paddingLeft="10dip"
+  android:paddingRight="10dip"
+  android:paddingTop="5dip">
 
-          <org.gdg.frisbee.android.view.SquaredImageView
-                  android:layout_width="32dp"
-                  android:layout_height="32dip"
-                  android:id="@+id/icon"
-                  android:layout_marginRight="8dip"
-            android:layout_alignParentLeft="true" />
+  <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dip"
+    card_view:cardCornerRadius="5dp">
 
-          <ImageButton
-              android:id="@+id/share_button"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:enabled="true"
-            android:layout_alignParentRight="true"
-            android:layout_marginLeft="8dp" android:background="@drawable/action_btn"
-            android:src="@drawable/ic_list_share"/>
+    <RelativeLayout
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
 
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-            android:layout_toRightOf="@+id/icon"
-            android:id="@+id/linearLayout"
-            android:layout_toLeftOf="@+id/share_button">
-                <TextView
-                        android:layout_width="fill_parent"
-                        android:layout_height="wrap_content"
-                        android:text="New Text"
-                        android:id="@+id/title" android:textStyle="bold"/>
-                <LinearLayout
-                        android:orientation="horizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="fill_parent">
-                    <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="New Text"
-                            android:id="@+id/line2" android:textColor="@color/line_2" android:layout_weight="1"/>
-                    <TextView
-                            android:layout_width="fill_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/past_event"
-                            android:id="@+id/past" android:layout_weight="3" android:textStyle="bold"
-                            android:gravity="right" android:visibility="visible"/>
-                </LinearLayout>
-            </LinearLayout>
-        </RelativeLayout>
-    </android.support.v7.widget.CardView>
+      <org.gdg.frisbee.android.view.SquaredImageView
+        android:id="@+id/icon"
+        android:layout_width="32dp"
+        android:layout_height="32dip"
+        android:layout_alignParentLeft="true"
+        android:layout_marginRight="8dip" />
+
+      <ImageButton
+        android:id="@+id/share_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_marginLeft="8dp"
+        android:background="@drawable/action_btn"
+        android:enabled="true"
+        android:src="@drawable/ic_list_share" />
+
+      <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_toLeftOf="@+id/share_button"
+        android:layout_toRightOf="@+id/icon"
+        android:orientation="vertical">
+
+        <TextView
+          android:id="@+id/title"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:text="New Text"
+          android:textStyle="bold" />
+
+        <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="fill_parent"
+          android:orientation="horizontal">
+
+          <TextView
+            android:id="@+id/line2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="New Text"
+            android:textColor="@color/line_2" />
+
+          <TextView
+            android:id="@+id/past"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="3"
+            android:gravity="right"
+            android:text="@string/past_event"
+            android:textStyle="bold"
+            android:visibility="visible" />
+        </LinearLayout>
+      </LinearLayout>
+    </RelativeLayout>
+  </android.support.v7.widget.CardView>
 </LinearLayout>

--- a/app/src/main/res/layout/list_organizer_item.xml
+++ b/app/src/main/res/layout/list_organizer_item.xml
@@ -17,23 +17,29 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="horizontal"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content" android:padding="8dip">
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="horizontal"
+  android:padding="8dip">
 
-    <ImageView
-            android:layout_width="32dp"
-            android:layout_height="32dip"
-            android:id="@+id/icon" android:layout_gravity="center_horizontal|top"
-            android:layout_marginRight="8dip"/>
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" android:gravity="center_vertical">
-        <TextView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="New Text"
-                android:id="@+id/title" android:textStyle="bold"/>
-    </LinearLayout>
+  <ImageView
+    android:id="@+id/icon"
+    android:layout_width="32dp"
+    android:layout_height="32dip"
+    android:layout_gravity="center_horizontal|top"
+    android:layout_marginRight="8dip" />
+
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:gravity="center_vertical"
+    android:orientation="vertical">
+
+    <TextView
+      android:id="@+id/title"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:text="New Text"
+      android:textStyle="bold" />
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/list_pulse_item.xml
+++ b/app/src/main/res/layout/list_pulse_item.xml
@@ -1,36 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:card_view="http://schemas.android.com/apk/res-auto"
-              android:orientation="horizontal"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content">
+  xmlns:card_view="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="horizontal">
 
-    <android.support.v7.widget.CardView
-        android:id="@+id/card_view"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        card_view:contentPadding="10dp"
-        card_view:cardCornerRadius="3dp" android:padding="10dip" android:layout_margin="5dip">
+  <android.support.v7.widget.CardView
+    android:id="@+id/card_view"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_margin="5dip"
+    android:padding="10dip"
+    card_view:cardCornerRadius="3dp"
+    card_view:contentPadding="10dp">
+
     <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="1."
-                android:id="@+id/position" android:layout_gravity="center_horizontal|top" android:textStyle="bold"/>
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="GDG Sampletown"
-                android:id="@+id/key" android:layout_gravity="center_horizontal|top" android:layout_marginLeft="5dip"/>
-        <TextView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="(00)"
-                android:id="@+id/value" android:layout_gravity="center_horizontal|top" android:gravity="right"/>
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="horizontal">
+
+      <TextView
+        android:id="@+id/position"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal|top"
+        android:text="1."
+        android:textStyle="bold" />
+
+      <TextView
+        android:id="@+id/key"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal|top"
+        android:layout_marginLeft="5dip"
+        android:text="GDG Sampletown" />
+
+      <TextView
+        android:id="@+id/value"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal|top"
+        android:gravity="right"
+        android:text="(00)" />
     </LinearLayout>
-    </android.support.v7.widget.CardView>
+  </android.support.v7.widget.CardView>
 </LinearLayout>

--- a/app/src/main/res/layout/list_resource_item.xml
+++ b/app/src/main/res/layout/list_resource_item.xml
@@ -2,6 +2,8 @@
 
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
-  android:layout_height="wrap_content" android:autoLink="all" android:padding="5dip">
+  android:layout_height="wrap_content"
+  android:autoLink="all"
+  android:padding="5dip">
 
 </TextView>

--- a/app/src/main/res/layout/list_tagged_organizer_item.xml
+++ b/app/src/main/res/layout/list_tagged_organizer_item.xml
@@ -18,36 +18,52 @@
 
 
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:card_view="http://schemas.android.com/apk/res-auto"
-              card_view:cardCornerRadius="5dp"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content" android:layout_marginLeft="8dip" android:layout_marginRight="8dip"
-              android:layout_marginTop="8dip">
-        <LinearLayout
-                android:orientation="horizontal"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" android:layout_gravity="left|center_vertical"
-                android:id="@+id/contentContainer">
-            <ImageView
-                    android:layout_width="40dip"
-                    android:layout_height="40dip"
-                    android:id="@+id/avatar" android:src="@drawable/ic_arrow_tagged"
-                    android:layout_gravity="center_vertical"/>
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content" android:padding="10dip">
-                <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="New Text"
-                        android:id="@+id/organizerName"
-                        android:autoLink="email|map|web" android:linksClickable="false"
-                        android:textStyle="bold" android:layout_marginBottom="5dip"/>
-                <TextView android:layout_width="match_parent" android:layout_height="wrap_content"
-                          android:text="New Text" android:id="@+id/organizerChapter"
-                          android:autoLink="email|map|web" android:linksClickable="false"/>
-            </LinearLayout>
+  xmlns:card_view="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:layout_marginLeft="8dip"
+  android:layout_marginRight="8dip"
+  android:layout_marginTop="8dip"
+  card_view:cardCornerRadius="5dp">
 
-        </LinearLayout>
+  <LinearLayout
+    android:id="@+id/contentContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="left|center_vertical"
+    android:orientation="horizontal">
+
+    <ImageView
+      android:id="@+id/avatar"
+      android:layout_width="40dip"
+      android:layout_height="40dip"
+      android:layout_gravity="center_vertical"
+      android:src="@drawable/ic_arrow_tagged" />
+
+    <LinearLayout
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:padding="10dip">
+
+      <TextView
+        android:id="@+id/organizerName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="5dip"
+        android:autoLink="email|map|web"
+        android:linksClickable="false"
+        android:text="New Text"
+        android:textStyle="bold" />
+
+      <TextView
+        android:id="@+id/organizerChapter"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autoLink="email|map|web"
+        android:linksClickable="false"
+        android:text="New Text" />
+    </LinearLayout>
+
+  </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/navigation_drawer.xml
+++ b/app/src/main/res/layout/navigation_drawer.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
-  android:id="@+id/drawer"
+<android.support.v4.widget.DrawerLayout android:id="@+id/drawer"
+  xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="fill_parent"
-  android:layout_height="fill_parent">
+  android:layout_height="fill_parent"
+  android:orientation="vertical">
 
   <FrameLayout
     android:id="@+id/content_container"
@@ -19,8 +19,8 @@
     android:layout_width="240dp"
     android:layout_height="match_parent"
     android:layout_gravity="start"
+    android:background="#111"
     android:choiceMode="singleChoice"
     android:divider="@android:color/transparent"
-    android:dividerHeight="0dp"
-    android:background="#111" />
+    android:dividerHeight="0dp" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/news_item_album.xml
+++ b/app/src/main/res/layout/news_item_album.xml
@@ -1,28 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="horizontal"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="horizontal">
+
+  <org.gdg.frisbee.android.view.SquaredImageView
+    android:id="@+id/pic1"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_column="0"
+    android:layout_row="0"
+    android:layout_rowSpan="2"
+    android:layout_weight="1"
+    android:adjustViewBounds="true" />
+
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="match_parent"
+    android:layout_weight="2"
+    android:orientation="vertical">
 
     <org.gdg.frisbee.android.view.SquaredImageView
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/pic1" android:layout_row="0" android:layout_column="0"
-            android:layout_rowSpan="2" android:layout_weight="1" android:adjustViewBounds="true" />
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="match_parent" android:layout_weight="2">
-        <org.gdg.frisbee.android.view.SquaredImageView
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:id="@+id/pic2" android:layout_row="0" android:layout_column="1" android:layout_weight="1"
-                android:adjustViewBounds="true"/>
-        <org.gdg.frisbee.android.view.SquaredImageView
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:id="@+id/pic3" android:layout_column="1" android:layout_row="1" android:layout_weight="1"
-                android:adjustViewBounds="true"/>
-    </LinearLayout>
+      android:id="@+id/pic2"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:layout_column="1"
+      android:layout_row="0"
+      android:layout_weight="1"
+      android:adjustViewBounds="true" />
+
+    <org.gdg.frisbee.android.view.SquaredImageView
+      android:id="@+id/pic3"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:layout_column="1"
+      android:layout_row="1"
+      android:layout_weight="1"
+      android:adjustViewBounds="true" />
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/news_item_article.xml
+++ b/app/src/main/res/layout/news_item_article.xml
@@ -1,37 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content" android:padding="10dip">
-    <View android:layout_width="fill_parent"
-          android:layout_height="1dip" android:background="@color/cloud" android:layout_marginBottom="5dip"
-          android:layout_marginLeft="5dip" android:layout_marginRight="5dip"></View>
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical"
+  android:padding="10dip">
+
+  <View
+    android:layout_width="fill_parent"
+    android:layout_height="1dip"
+    android:layout_marginBottom="5dip"
+    android:layout_marginLeft="5dip"
+    android:layout_marginRight="5dip"
+    android:background="@color/cloud"></View>
+
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="horizontal">
+
+    <org.gdg.frisbee.android.view.ResizableImageView
+      android:id="@+id/image"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal|top"
+      android:layout_weight="2" />
+
     <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
-        <org.gdg.frisbee.android.view.ResizableImageView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/image" android:layout_gravity="center_horizontal|top" android:layout_weight="2"
-                />
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content" android:layout_marginLeft="10dip" android:layout_weight="1">
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:text="New Text"
-                    android:id="@+id/displayName"
-                    android:layout_marginBottom="10dip" android:autoLink="email|map|web"/>
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:text="New Text"
-                    android:id="@+id/content" android:textColor="@color/asbestos"
-                    android:textAppearance="@android:style/TextAppearance.Small" android:autoLink="email|map|web"/>
-        </LinearLayout>
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="10dip"
+      android:layout_weight="1"
+      android:orientation="vertical">
+
+      <TextView
+        android:id="@+id/displayName"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dip"
+        android:autoLink="email|map|web"
+        android:text="New Text" />
+
+      <TextView
+        android:id="@+id/content"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:autoLink="email|map|web"
+        android:text="New Text"
+        android:textAppearance="@android:style/TextAppearance.Small"
+        android:textColor="@color/asbestos" />
     </LinearLayout>
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/news_item_base.xml
+++ b/app/src/main/res/layout/news_item_base.xml
@@ -17,69 +17,98 @@
   -->
 
 <LinearLayout
-    android:layout_height="wrap_content" android:layout_width="fill_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-<android.support.v7.widget.CardView
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
-    card_view:cardCornerRadius="5dp"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="wrap_content">
+
+  <android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" android:layout_marginLeft="8dip" android:layout_marginRight="8dip"
-    android:layout_marginBottom="4dip" android:layout_marginTop="4dip">
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="4dip"
+    android:layout_marginLeft="8dip"
+    android:layout_marginRight="8dip"
+    android:layout_marginTop="4dip"
+    card_view:cardCornerRadius="5dp">
+
     <LinearLayout
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical">
+
+      <LinearLayout
+        android:id="@+id/contentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left|center_vertical"
+        android:orientation="vertical">
+
+        <TextView
+          android:id="@+id/content"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:autoLink="email|map|web"
+          android:linksClickable="true"
+          android:padding="10dip"
+          android:text="New Text" />
+
+        <LinearLayout
+          android:id="@+id/shareContainer"
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:orientation="vertical"
+          android:visibility="gone">
+
+          <View
+            android:layout_width="fill_parent"
+            android:layout_height="1dip"
+            android:layout_marginBottom="5dip"
+            android:layout_marginLeft="5dip"
+            android:layout_marginRight="5dip"
+            android:background="@color/cloud"></View>
+
+          <TextView
+            android:id="@+id/shareContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autoLink="all"
+            android:linksClickable="true"
+            android:padding="10dip"
+            android:text="New Text" />
+        </LinearLayout>
+      </LinearLayout>
+
+      <LinearLayout
+        android:id="@+id/attachmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"></LinearLayout>
+
+      <LinearLayout
+        android:id="@+id/options"
         android:layout_width="fill_parent"
-        android:layout_height="fill_parent" android:orientation="vertical">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" android:layout_gravity="left|center_vertical"
-                android:id="@+id/contentContainer">
-            <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="New Text"
-                    android:id="@+id/content"
-                    android:padding="10dip" android:autoLink="email|map|web" android:linksClickable="true"/>
-            <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" android:id="@+id/shareContainer" android:visibility="gone">
-                <View android:layout_width="fill_parent"
-                      android:layout_height="1dip" android:background="@color/cloud" android:layout_marginBottom="5dip"
-                      android:layout_marginLeft="5dip" android:layout_marginRight="5dip"></View>
-                <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="New Text"
-                        android:id="@+id/shareContent"
-                        android:padding="10dip" android:autoLink="all" android:linksClickable="true"/>
-            </LinearLayout>
-        </LinearLayout>
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" android:id="@+id/attachmentContainer"
-                >
-        </LinearLayout>
-        <LinearLayout
-                android:orientation="horizontal"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content" android:id="@+id/options"
-                android:paddingLeft="10dip" android:paddingTop="10dip" android:paddingBottom="15dip"
-                android:paddingRight="10dip">
-            <com.google.android.gms.plus.PlusOneButton
-                    xmlns:plus="http://schemas.android.com/apk/lib/com.google.android.gms.plus"
-                    android:id="@+id/plus_one_button"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    plus:size="standard"
-                    plus:annotation="inline" />
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:text="New Text"
-                    android:id="@+id/timestamp" android:gravity="right" android:textColor="@color/asbestos"
-                    android:paddingTop="2dip"/>
-        </LinearLayout>
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingBottom="15dip"
+        android:paddingLeft="10dip"
+        android:paddingRight="10dip"
+        android:paddingTop="10dip">
+
+        <com.google.android.gms.plus.PlusOneButton android:id="@+id/plus_one_button"
+          xmlns:plus="http://schemas.android.com/apk/lib/com.google.android.gms.plus"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          plus:annotation="inline"
+          plus:size="standard" />
+
+        <TextView
+          android:id="@+id/timestamp"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:gravity="right"
+          android:paddingTop="2dip"
+          android:text="New Text"
+          android:textColor="@color/asbestos" />
+      </LinearLayout>
     </LinearLayout>
-</android.support.v7.widget.CardView>
+  </android.support.v7.widget.CardView>
 </LinearLayout>

--- a/app/src/main/res/layout/news_item_event.xml
+++ b/app/src/main/res/layout/news_item_event.xml
@@ -1,33 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content">
-    <View android:layout_width="fill_parent"
-          android:layout_height="1dip" android:background="@color/cloud" android:layout_marginBottom="5dip"
-          android:layout_marginLeft="5dip" android:layout_marginRight="5dip"></View>
-    <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-        <ImageView
-          android:layout_width="40dip"
-          android:layout_height="40dip"
-          android:id="@+id/image" android:src="@drawable/no_events" android:paddingLeft="10dip"/>
-        <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textStyle="bold"
-        android:id="@+id/title"
-        android:padding="10dip" />
-    </LinearLayout>
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical">
+
+  <View
+    android:layout_width="fill_parent"
+    android:layout_height="1dip"
+    android:layout_marginBottom="5dip"
+    android:layout_marginLeft="5dip"
+    android:layout_marginRight="5dip"
+    android:background="@color/cloud"></View>
+
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <ImageView
+      android:id="@+id/image"
+      android:layout_width="40dip"
+      android:layout_height="40dip"
+      android:paddingLeft="10dip"
+      android:src="@drawable/no_events" />
+
     <TextView
+      android:id="@+id/title"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:padding="10dip"
+      android:textStyle="bold" />
+  </LinearLayout>
+
+  <TextView
+    android:id="@+id/content"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:text="New Text"
-    android:id="@+id/content"
+    android:autoLink="email|map|web"
     android:padding="10dip"
-    android:autoLink="email|map|web" />
+    android:text="New Text" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/news_item_photo.xml
+++ b/app/src/main/res/layout/news_item_photo.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content">
-    <org.gdg.frisbee.android.view.ResizableImageView android:layout_width="match_parent"
-                                                     android:layout_height="wrap_content" android:id="@+id/photo"/>
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical">
+
+  <org.gdg.frisbee.android.view.ResizableImageView
+    android:id="@+id/photo"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/main/res/layout/news_item_video.xml
+++ b/app/src/main/res/layout/news_item_video.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content">
-    <org.gdg.frisbee.android.view.ResizableImageView android:layout_width="match_parent"
-                                                     android:layout_height="wrap_content" android:id="@+id/videoPoster"/>
-    <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:id="@+id/imageView" android:src="@drawable/video_play" android:scaleType="centerInside"/>
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical">
+
+  <org.gdg.frisbee.android.view.ResizableImageView
+    android:id="@+id/videoPoster"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+
+  <ImageView
+    android:id="@+id/imageView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:scaleType="centerInside"
+    android:src="@drawable/video_play" />
 </FrameLayout>

--- a/app/src/main/res/layout/organizer_item.xml
+++ b/app/src/main/res/layout/organizer_item.xml
@@ -17,8 +17,8 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
 </LinearLayout>

--- a/app/src/main/res/layout/tab_indicator.xml
+++ b/app/src/main/res/layout/tab_indicator.xml
@@ -1,0 +1,31 @@
+<!--
+  Copyright 2014 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<TextView
+  android:id="@android:id/text1"
+  style="@style/TabIndicator"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="wrap_content"
+  android:layout_height="48dp"
+  android:background="?attr/selectableItemBackground"
+  android:fontFamily="@string/font_fontFamily_medium"
+  android:gravity="center"
+  android:paddingLeft="16dp"
+  android:paddingRight="16dp"
+  android:textAllCaps="true"
+  android:textColor="@color/tab_text_color"
+  android:textSize="@dimen/text_size_small"
+  android:textStyle="@integer/font_textStyle_medium" />

--- a/app/src/main/res/layout/widget_upcoming_event.xml
+++ b/app/src/main/res/layout/widget_upcoming_event.xml
@@ -1,76 +1,119 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout android:id="@+id/container"
+  xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content" android:background="@drawable/appwidget_dark_bg"
-              android:paddingTop="8dip" android:paddingLeft="4dip" android:paddingRight="4dip"
-              android:paddingBottom="4dip" android:id="@+id/container">
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:background="@drawable/appwidget_dark_bg"
+  android:orientation="vertical"
+  android:paddingBottom="4dip"
+  android:paddingLeft="4dip"
+  android:paddingRight="4dip"
+  android:paddingTop="8dip">
 
-    <ViewFlipper
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/viewFlipper">
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:id="@+id/noEventContainer">
-            <LinearLayout android:orientation="horizontal" android:layout_width="fill_parent"
-                          android:layout_height="wrap_content" android:id="@+id/linearLayout">
-                <ImageView android:layout_width="40dip" android:layout_height="20dip" android:id="@+id/imageView1"
-                           android:src="@drawable/ic_logo_wide_light"/>
-                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
-                          tools:text="Brussels" android:id="@+id/groupName2" android:layout_gravity="center"
-                          android:textColor="@android:color/primary_text_dark" android:layout_marginLeft="4dip"
-                          android:textSize="11sp"/>
-            </LinearLayout>
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:text="@string/no_scheduled_events"
-                    android:id="@+id/textView_no_events" android:gravity="center_vertical|center_horizontal"
-                    android:textColor="@android:color/primary_text_dark"/>
-        </LinearLayout>
-        <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent" android:id="@+id/eventContainer" android:padding="3dip">
-            <LinearLayout
-                    android:orientation="horizontal"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content">
-                <ImageView
-                        android:layout_width="40dip"
-                        android:layout_height="20dip"
-                        android:id="@+id/imageView" android:src="@drawable/ic_logo_wide_light"/>
-                <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        tools:text="Brussels"
-                        android:id="@+id/groupName" android:layout_gravity="center"
-                        android:textColor="@android:color/primary_text_dark" android:layout_marginLeft="4dip"
-                        android:textSize="11sp"/>
-                <TextView
-                        android:layout_width="fill_parent"
-                        android:layout_height="wrap_content"
-                        tools:text="27.08.2013"
-                        android:id="@+id/startDate" android:layout_gravity="center" android:textSize="11sp"
-                        android:textColor="@android:color/primary_text_dark" android:gravity="right"/>
-            </LinearLayout>
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    tools:text="Brussels GTUG travelling to Droidcon London"
-                    android:id="@+id/title" android:gravity="right" android:textColor="@android:color/primary_text_dark"
-                    android:textStyle="bold" android:ellipsize="end" android:maxLines="1"/>
-            <TextView
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    tools:text="Room 720 at 10 Floor Building F"
-                    android:id="@+id/location" android:gravity="right" android:textColor="@android:color/primary_text_dark"
-                    android:ellipsize="end" android:maxLines="1"/>
-        </LinearLayout>
-    </ViewFlipper>
+  <ViewFlipper
+    android:id="@+id/viewFlipper"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
+
+    <LinearLayout
+      android:id="@+id/noEventContainer"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical">
+
+      <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageView
+          android:id="@+id/imageView1"
+          android:layout_width="40dip"
+          android:layout_height="20dip"
+          android:src="@drawable/ic_logo_wide_light" />
+
+        <TextView
+          android:id="@+id/groupName2"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          android:layout_marginLeft="4dip"
+          android:textColor="@android:color/primary_text_dark"
+          android:textSize="11sp"
+          tools:text="Brussels" />
+      </LinearLayout>
+
+      <TextView
+        android:id="@+id/textView_no_events"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:gravity="center_vertical|center_horizontal"
+        android:text="@string/no_scheduled_events"
+        android:textColor="@android:color/primary_text_dark" />
+    </LinearLayout>
+
+    <LinearLayout
+      android:id="@+id/eventContainer"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:orientation="vertical"
+      android:padding="3dip">
+
+      <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageView
+          android:id="@+id/imageView"
+          android:layout_width="40dip"
+          android:layout_height="20dip"
+          android:src="@drawable/ic_logo_wide_light" />
+
+        <TextView
+          android:id="@+id/groupName"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          android:layout_marginLeft="4dip"
+          android:textColor="@android:color/primary_text_dark"
+          android:textSize="11sp"
+          tools:text="Brussels" />
+
+        <TextView
+          android:id="@+id/startDate"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          android:gravity="right"
+          android:textColor="@android:color/primary_text_dark"
+          android:textSize="11sp"
+          tools:text="27.08.2013" />
+      </LinearLayout>
+
+      <TextView
+        android:id="@+id/title"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:gravity="right"
+        android:maxLines="1"
+        android:textColor="@android:color/primary_text_dark"
+        android:textStyle="bold"
+        tools:text="Brussels GTUG travelling to Droidcon London" />
+
+      <TextView
+        android:id="@+id/location"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:gravity="right"
+        android:maxLines="1"
+        android:textColor="@android:color/primary_text_dark"
+        tools:text="Room 720 at 10 Floor Building F" />
+    </LinearLayout>
+  </ViewFlipper>
 </LinearLayout>

--- a/app/src/main/res/values-v21/fonts.xml
+++ b/app/src/main/res/values-v21/fonts.xml
@@ -1,0 +1,21 @@
+<!--
+  Copyright 2014 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+  <integer name="font_textStyle_medium">0</integer>
+  <!-- normal -->
+  <string name="font_fontFamily_medium">sans-serif-medium</string>
+</resources>

--- a/app/src/main/res/values-v21/gdg_styles.xml
+++ b/app/src/main/res/values-v21/gdg_styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style name="TabIndicator">
+    <item name="android:theme">@style/ActionBarThemeOverlay</item>
+  </style>
+
+</resources>

--- a/app/src/main/res/values-v21/gdg_themes.xml
+++ b/app/src/main/res/values-v21/gdg_themes.xml
@@ -18,7 +18,6 @@
 
 <resources>
   <style name="Theme.GDG" parent="Theme.GDG.Base">
-    <item name="vpiTitlePageIndicatorStyle">@style/TitlePageIndicatorGDG</item>
     <item name="android:windowBackground">@color/default_bg</item>
   </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,21 +17,25 @@
 -->
 
 <resources>
-    <color name="story_red">#e46f61</color>
-    <color name="people_blue">#76a7fa</color>
-    <color name="contact_yellow">#f9b256</color>
-    <color name="line_2">#757575</color>
-    <color name="grey_border">#d0d0d0</color>
-    <color name="shadow">#dcdcdc</color>
-    <color name="white">#FFFFFF</color>
-    <color name="peter_river">#3498db</color>
-    <color name="cloud">#ECF0F1</color>
-    <color name="silver">#BDC3C7</color>
-    <color name="concrete">#95A5A6</color>
-    <color name="asbestos">#7F8C8D</color>
-    <color name="semi_transparent">#96000000</color>
-    <color name="default_bg">#e5e5e5</color>
-    <color name="light_semi_transparent">#b6e0e0e0</color>
-    <color name="material_blue_500">#2196F3</color>
-    <color name="material_blue_700">#1976D2</color>
+  <color name="story_red">#e46f61</color>
+  <color name="people_blue">#76a7fa</color>
+  <color name="contact_yellow">#f9b256</color>
+  <color name="line_2">#757575</color>
+  <color name="grey_border">#d0d0d0</color>
+  <color name="shadow">#dcdcdc</color>
+  <color name="white">#FFFFFF</color>
+  <color name="peter_river">#3498db</color>
+  <color name="cloud">#ECF0F1</color>
+  <color name="silver">#BDC3C7</color>
+  <color name="concrete">#95A5A6</color>
+  <color name="asbestos">#7F8C8D</color>
+  <color name="semi_transparent">#96000000</color>
+  <color name="default_bg">#e5e5e5</color>
+  <color name="light_semi_transparent">#b6e0e0e0</color>
+  <color name="material_blue_500">#2196F3</color>
+  <color name="material_blue_700">#1976D2</color>
+  <color name="tab_text_color">@android:color/white</color>
+  <color name="tab_selected_strip">@color/theme_accent_1</color>
+  <color name="theme_primary">@color/material_blue_500</color>
+  <color name="theme_accent_1">@android:color/white</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <dimen name="logo_size">50dip</dimen>
+  <dimen name="text_size_small">12sp</dimen>
 </resources>

--- a/app/src/main/res/values/fonts.xml
+++ b/app/src/main/res/values/fonts.xml
@@ -1,0 +1,21 @@
+<!--
+  Copyright 2014 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+  <integer name="font_textStyle_medium">1</integer>
+  <!-- bold -->
+  <string name="font_fontFamily_medium">sans-serif</string>
+</resources>

--- a/app/src/main/res/values/gdg_styles.xml
+++ b/app/src/main/res/values/gdg_styles.xml
@@ -26,28 +26,6 @@
         <item name="android:textSize">18sp</item>
     </style>
 
-    <style name="TitlePageIndicatorGDG">
-        <item name="android:background">#444444</item>
-        <item name="footerColor">#ffffff</item>
-        <item name="footerLineHeight">0dp</item>
-        <item name="footerIndicatorHeight">3dp</item>
-        <item name="footerIndicatorStyle">underline</item>
-        <item name="android:textColor">#ffffff</item>
-        <item name="selectedColor">#ffffff</item>
-        <item name="selectedBold">true</item>
-    </style>
-
-    <style name="TitlePageIndicatorSecondGDG">
-        <item name="android:background">#9f9f9f</item>
-        <item name="footerColor">#ffffff</item>
-        <item name="footerLineHeight">0dp</item>
-        <item name="footerIndicatorHeight">3dp</item>
-        <item name="footerIndicatorStyle">underline</item>
-        <item name="android:textColor">#ffffff</item>
-        <item name="selectedColor">#ffffff</item>
-        <item name="selectedBold">true</item>
-    </style>
-
   <style name="EditTextGDG" parent="android:Widget.EditText">
 	  <item name="android:background">@drawable/edit_text_holo_light</item>
 	  <item name="android:textColor">#000000</item>

--- a/app/src/main/res/values/gdg_styles.xml
+++ b/app/src/main/res/values/gdg_styles.xml
@@ -19,101 +19,109 @@
 <!-- Generated with http://android-holo-colors.com -->
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="GoogleSignIn" parent="android:style/Widget.Button">
-        <item name="android:textColor">@color/white</item>
-        <item name="android:paddingLeft">65dip</item>
-        <item name="android:paddingRight">25dip</item>
-        <item name="android:textSize">18sp</item>
-    </style>
+  <style name="GoogleSignIn" parent="android:style/Widget.Button">
+    <item name="android:textColor">@color/white</item>
+    <item name="android:paddingLeft">65dip</item>
+    <item name="android:paddingRight">25dip</item>
+    <item name="android:textSize">18sp</item>
+  </style>
 
   <style name="EditTextGDG" parent="android:Widget.EditText">
-	  <item name="android:background">@drawable/edit_text_holo_light</item>
-	  <item name="android:textColor">#000000</item>
+    <item name="android:background">@drawable/edit_text_holo_light</item>
+    <item name="android:textColor">#000000</item>
   </style>
 
   <style name="AutoCompleteTextViewGDG" parent="android:Widget.AutoCompleteTextView">
-      <item name="android:dropDownSelector">@drawable/list_selector_holo_light</item>
-	  <item name="android:background">@drawable/edit_text_holo_light</item>
-	  <item name="android:textColor">#000000</item>
+    <item name="android:dropDownSelector">@drawable/list_selector_holo_light</item>
+    <item name="android:background">@drawable/edit_text_holo_light</item>
+    <item name="android:textColor">#000000</item>
   </style>
 
   <style name="CheckBoxGDG" parent="android:Widget.CompoundButton.CheckBox">
-      <item name="android:button">@drawable/btn_check_holo_light</item>
+    <item name="android:button">@drawable/btn_check_holo_light</item>
   </style>
 
   <style name="RadioButtonGDG" parent="android:Widget.CompoundButton.RadioButton">
-      <item name="android:button">@drawable/btn_radio_holo_light</item>
+    <item name="android:button">@drawable/btn_radio_holo_light</item>
   </style>
 
   <style name="ButtonGDG" parent="android:Widget.Button">
-	  <item name="android:background">@drawable/btn_default_holo_light</item>
-	  <item name="android:minHeight">48dip</item>
-	  <item name="android:minWidth">64dip</item>
-	  <item name="android:textColor">#000000</item>
+    <item name="android:background">@drawable/btn_default_holo_light</item>
+    <item name="android:minHeight">48dip</item>
+    <item name="android:minWidth">64dip</item>
+    <item name="android:textColor">#000000</item>
   </style>
 
   <style name="ImageButtonGDG" parent="android:Widget.ImageButton">
-	  <item name="android:background">@drawable/btn_default_holo_light</item>
+    <item name="android:background">@drawable/btn_default_holo_light</item>
   </style>
 
   <style name="SpinnerGDG" parent="android:Widget.Spinner">
-      <item name="android:background">@drawable/spinner_background_holo_light</item>
-      <item name="android:dropDownSelector">@drawable/list_selector_holo_light</item>
+    <item name="android:background">@drawable/spinner_background_holo_light</item>
+    <item name="android:dropDownSelector">@drawable/list_selector_holo_light</item>
   </style>
 
   <style name="SpinnerGDG.DropDown">
-      <item name="android:spinnerMode">dropdown</item>
+    <item name="android:spinnerMode">dropdown</item>
   </style>
 
   <style name="SpinnerDropDownItemGDG" parent="android:Widget.DropDownItem.Spinner">
-      <item name="android:checkMark">@drawable/btn_radio_holo_light</item>
+    <item name="android:checkMark">@drawable/btn_radio_holo_light</item>
   </style>
 
   <style name="SeekBarGDG" parent="android:Widget.SeekBar">
-      <item name="android:progressDrawable">@drawable/scrubber_progress_horizontal_holo_light</item>
-      <item name="android:indeterminateDrawable">@drawable/scrubber_progress_horizontal_holo_light</item>
-      <item name="android:minHeight">13dip</item>
-      <item name="android:maxHeight">13dip</item>
-      <item name="android:thumb">@drawable/scrubber_control_selector_holo_light</item>
-      <item name="android:thumbOffset">16dip</item>
-      <item name="android:paddingLeft">16dip</item>
-      <item name="android:paddingRight">16dip</item>
+    <item name="android:progressDrawable">@drawable/scrubber_progress_horizontal_holo_light</item>
+    <item name="android:indeterminateDrawable">@drawable/scrubber_progress_horizontal_holo_light</item>
+    <item name="android:minHeight">13dip</item>
+    <item name="android:maxHeight">13dip</item>
+    <item name="android:thumb">@drawable/scrubber_control_selector_holo_light</item>
+    <item name="android:thumbOffset">16dip</item>
+    <item name="android:paddingLeft">16dip</item>
+    <item name="android:paddingRight">16dip</item>
   </style>
 
   <style name="RatingBarGDG" parent="android:Widget.RatingBar">
-      <item name="android:progressDrawable">@drawable/ratingbar_full_holo_light</item>
-      <item name="android:indeterminateDrawable">@drawable/ratingbar_full_holo_light</item>
+    <item name="android:progressDrawable">@drawable/ratingbar_full_holo_light</item>
+    <item name="android:indeterminateDrawable">@drawable/ratingbar_full_holo_light</item>
   </style>
 
   <style name="RatingBarBigGDG">
-      <item name="android:progressDrawable">@drawable/ratingbar_holo_light</item>
-      <item name="android:indeterminateDrawable">@drawable/ratingbar_holo_light</item>
-      <item name="android:minHeight">35dip</item>
-      <item name="android:maxHeight">35dip</item>
+    <item name="android:progressDrawable">@drawable/ratingbar_holo_light</item>
+    <item name="android:indeterminateDrawable">@drawable/ratingbar_holo_light</item>
+    <item name="android:minHeight">35dip</item>
+    <item name="android:maxHeight">35dip</item>
   </style>
 
   <style name="RatingBarSmallGDG">
-      <item name="android:progressDrawable">@drawable/ratingbar_small_holo_light</item>
-      <item name="android:indeterminateDrawable">@drawable/ratingbar_small_holo_light</item>
-      <item name="android:minHeight">16dip</item>
-      <item name="android:maxHeight">16dip</item>
+    <item name="android:progressDrawable">@drawable/ratingbar_small_holo_light</item>
+    <item name="android:indeterminateDrawable">@drawable/ratingbar_small_holo_light</item>
+    <item name="android:minHeight">16dip</item>
+    <item name="android:maxHeight">16dip</item>
   </style>
 
   <style name="ToggleGDG" parent="android:Widget.Button.Toggle">
-      <item name="android:background">@drawable/btn_toggle_holo_light</item>
-      <item name="android:minHeight">48dip</item>
+    <item name="android:background">@drawable/btn_toggle_holo_light</item>
+    <item name="android:minHeight">48dip</item>
   </style>
 
   <style name="ListViewGDG" parent="android:Widget.ListView">
-      <item name="android:listSelector">@drawable/list_selector_holo_light</item>
+    <item name="android:listSelector">@drawable/list_selector_holo_light</item>
   </style>
 
   <style name="ListViewGDG.White" parent="android:Widget.ListView.White">
-      <item name="android:listSelector">@drawable/list_selector_holo_light</item>
+    <item name="android:listSelector">@drawable/list_selector_holo_light</item>
   </style>
 
   <style name="SpinnerItemGDG" parent="android:TextAppearance.Widget.TextView.SpinnerItem">
-      <item name="android:textColor">#000000</item>
+    <item name="android:textColor">#000000</item>
+  </style>
+
+  <style name="TabIndicator" />
+
+  <style name="ActionBarThemeOverlay" parent="">
+    <item name="android:textColorPrimary">#fff</item>
+    <item name="colorControlNormal">@android:color/white</item>
+    <item name="colorControlHighlight">#3fff</item>
   </style>
 
 </resources>

--- a/app/src/main/res/values/gdg_themes.xml
+++ b/app/src/main/res/values/gdg_themes.xml
@@ -39,7 +39,6 @@
   </style>
 
   <style name="Theme.GDG" parent="Theme.GDG.Base">
-    <item name="vpiTitlePageIndicatorStyle">@style/TitlePageIndicatorGDG</item>
     <item name="android:windowBackground">@color/default_bg</item>
     <item name="android:editTextStyle">@style/EditTextGDG</item>
 

--- a/app/src/main/res/values/gdg_themes.xml
+++ b/app/src/main/res/values/gdg_themes.xml
@@ -20,22 +20,23 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
   <style name="Theme.GDG.Base" parent="Theme.AppCompat.Light.DarkActionBar">
+    <item name="android:windowContentOverlay">@null</item>
     <item name="colorPrimary">@color/material_blue_500</item>
     <item name="colorPrimaryDark">@color/material_blue_700</item>
   </style>
 
   <style name="GDG.SeeTrough" parent="Theme.GDG">
-      <item name="android:windowIsTranslucent">true</item>
-      <item name="android:windowBackground">@color/semi_transparent</item>
-      <item name="android:windowContentOverlay">@null</item>
-      <item name="android:windowNoTitle">true</item>
-      <item name="android:backgroundDimEnabled">false</item>
-      <item name="windowActionBar">false</item>
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowBackground">@color/semi_transparent</item>
+    <item name="android:windowContentOverlay">@null</item>
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:backgroundDimEnabled">false</item>
+    <item name="windowActionBar">false</item>
   </style>
 
   <style name="GDG.NoActionBar" parent="Theme.GDG">
-      <item name="windowActionBar">false</item>
-      <item name="android:windowNoTitle">true</item>
+    <item name="windowActionBar">false</item>
+    <item name="android:windowNoTitle">true</item>
   </style>
 
   <style name="Theme.GDG" parent="Theme.GDG.Base">


### PR DESCRIPTION
Replace usage of ViewPagerIndicator with SlidingTabLayout.

Please read issue #170 for more information.

### Before
![viewpagerindicator](https://cloud.githubusercontent.com/assets/140122/6305656/ccde7188-b924-11e4-8c02-a234c06ce731.png)

### After
![sliding_tabs](https://cloud.githubusercontent.com/assets/140122/6305658/cde2c408-b924-11e4-8d29-89c772903d15.png)

![about_tabs](https://cloud.githubusercontent.com/assets/140122/6305857/21e87c36-b926-11e4-91bd-a7c3c8c887fb.png)

Fixes #170 
