### PR TITLE
Fix content provider app crash

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/provider/GdgProvider.java
+++ b/app/src/main/java/org/gdg/frisbee/android/provider/GdgProvider.java
@@ -29,7 +29,6 @@ import org.gdg.frisbee.android.activity.SearchActivity;
 import org.gdg.frisbee.android.api.model.Chapter;
 import org.gdg.frisbee.android.api.model.Directory;
 import org.gdg.frisbee.android.app.App;
-import org.gdg.frisbee.android.cache.ModelCache;
 
 import timber.log.Timber;
 
@@ -61,7 +60,7 @@ public class GdgProvider extends ContentProvider {
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
                         String sortOrder) {
 
-        if(! isSetupDone()) {
+        if (!isSetupDone()) {
             prepareProvider();
         }
 

--- a/app/src/main/java/org/gdg/frisbee/android/provider/GdgProvider.java
+++ b/app/src/main/java/org/gdg/frisbee/android/provider/GdgProvider.java
@@ -44,6 +44,7 @@ public class GdgProvider extends ContentProvider {
     private static final int SEARCH_SUGGEST = 0;
 
     private static UriMatcher uriMatcher;
+
     static {
         uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
         uriMatcher.addURI(AUTHORITY, SearchManager.SUGGEST_URI_PATH_QUERY, SEARCH_SUGGEST);
@@ -53,33 +54,37 @@ public class GdgProvider extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        App.getInstance().getModelCache().getAsync("chapter_list_hub", false, new ModelCache.CacheListener() {
-            @Override
-            public void onGet(Object item) {
-                mDirectory = (Directory)item;
-                Timber.d("Initialized ContentProvider");
-            }
-
-            @Override
-            public void onNotFound(String key) {
-            }
-        });
         return true;
     }
 
     @Override
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
                         String sortOrder) {
+
+        if(! isSetupDone()) {
+            prepareProvider();
+        }
+
         String searchString = uri.getLastPathSegment();
         return getSuggestions(searchString);
+    }
+
+    private boolean isSetupDone() {
+        return mDirectory != null;
+    }
+
+    private void prepareProvider() {
+        final App app = (App) getContext().getApplicationContext();
+        mDirectory = (Directory) app.getInstance().getModelCache().get("chapter_list_hub");
+        Timber.d("Initialized ContentProvider");
     }
 
     private MatrixCursor getSuggestions(String query) {
         MatrixCursor cursor = new MatrixCursor(CHAPTER_COLUMNS);
 
-        for(Chapter chapter : mDirectory.getGroups()) {
-            if(chapter.getName().toLowerCase().contains(query.toLowerCase())) {
-                cursor.addRow(new Object[] { chapter.getGplusId(), chapter.getName(), chapter.getCity()+", "+chapter.getCountry(), SearchActivity.ACTION_FOUND, chapter.getGplusId() });
+        for (Chapter chapter : mDirectory.getGroups()) {
+            if (chapter.getName().toLowerCase().contains(query.toLowerCase())) {
+                cursor.addRow(new Object[]{chapter.getGplusId(), chapter.getName(), chapter.getCity() + ", " + chapter.getCountry(), SearchActivity.ACTION_FOUND, chapter.getGplusId()});
             }
         }
         return cursor;


### PR DESCRIPTION
With the current develop branch the app crashed on startup for me. Investigation lead to the point in which the content provider tried to access the model cache via the app's instance but this was not created yet so it caused an NPE. 

It seems the onCreate of the content provider is executed before the app's onCreate is done. To avoid such race conditions I moved the init of the content provider's list into the first query. Since this is already off-main thread I could simplify the call into a synchronous call.

With this fix my local version could start again and display the list of GDGs.