### PR TITLE
211/Use IO extended for special events

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,7 +71,7 @@
     <activity android:name=".activity.MainActivity" />
     <activity android:name=".activity.GdeActivity" />
     <activity android:name=".activity.AboutActivity" />
-    <activity android:name=".activity.SpecialEventActivity" />
+    <activity android:name=".special.SpecialEventActivity" />
     <activity android:name=".activity.SettingsActivity" />
     <activity
       android:name=".activity.ArrowActivity"

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
@@ -44,6 +44,7 @@ import de.keyboardsurfer.android.widget.crouton.Style;
 
 public abstract class GdgNavDrawerActivity extends GdgActivity {
 
+    private static final long DATE_2015_06_01_GMT_IN_MILLIS = 1433116800000L;
     protected DrawerAdapter mDrawerAdapter;
     protected ActionBarDrawerToggle mDrawerToggle;
     @InjectView(R.id.drawer)
@@ -93,12 +94,12 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
                         break;
                     case Const.DRAWER_SPECIAL:
                         Bundle special = new Bundle();
-                        special.putInt(Const.SPECIAL_EVENT_LOGO_EXTRA, R.drawable.ic_logo_devfest);
-                        special.putString(Const.SPECIAL_EVENT_VIEWTAG_EXTRA, "devfest");
-                        special.putString(Const.SPECIAL_EVENT_CACHEKEY_EXTRA, "devfest");
+                        special.putInt(Const.SPECIAL_EVENT_LOGO_EXTRA, R.drawable.ioextended);
+                        special.putString(Const.SPECIAL_EVENT_VIEWTAG_EXTRA, "io-extended");
+                        special.putString(Const.SPECIAL_EVENT_CACHEKEY_EXTRA, "io-extended");
                         special.putLong(Const.SPECIAL_EVENT_START_EXTRA, DateTime.now().getMillis());
-                        special.putLong(Const.SPECIAL_EVENT_END_EXTRA, 1419984000000L);
-                        special.putInt(Const.SPECIAL_EVENT_DESCRIPTION_EXTRA, R.string.devfest_description);
+                        special.putLong(Const.SPECIAL_EVENT_END_EXTRA, DATE_2015_06_01_GMT_IN_MILLIS);
+                        special.putInt(Const.SPECIAL_EVENT_DESCRIPTION_EXTRA, R.string.ioextended_description);
                         navigateTo(SpecialEventActivity.class, special);
                         break;
                     case Const.DRAWER_PULSE:

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
@@ -36,6 +36,8 @@ import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.adapter.DrawerAdapter;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.app.OrganizerChecker;
+import org.gdg.frisbee.android.special.SpecialEventActivity;
+import org.gdg.frisbee.android.special.SpecialEvents;
 import org.joda.time.DateTime;
 
 import butterknife.InjectView;
@@ -44,7 +46,6 @@ import de.keyboardsurfer.android.widget.crouton.Style;
 
 public abstract class GdgNavDrawerActivity extends GdgActivity {
 
-    private static final long DATE_2015_06_01_GMT_IN_MILLIS = 1433116800000L;
     protected DrawerAdapter mDrawerAdapter;
     protected ActionBarDrawerToggle mDrawerToggle;
     @InjectView(R.id.drawer)
@@ -93,13 +94,14 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
                         navigateTo(GdeActivity.class, null);
                         break;
                     case Const.DRAWER_SPECIAL:
+                        SpecialEvents specialEvents = SpecialEvents.getCurrent();
                         Bundle special = new Bundle();
-                        special.putInt(Const.SPECIAL_EVENT_LOGO_EXTRA, R.drawable.ioextended);
-                        special.putString(Const.SPECIAL_EVENT_VIEWTAG_EXTRA, "io-extended");
-                        special.putString(Const.SPECIAL_EVENT_CACHEKEY_EXTRA, "io-extended");
+                        special.putInt(Const.SPECIAL_EVENT_LOGO_EXTRA, specialEvents.getLogoResId());
+                        special.putString(Const.SPECIAL_EVENT_VIEWTAG_EXTRA, specialEvents.getTag());
+                        special.putString(Const.SPECIAL_EVENT_CACHEKEY_EXTRA, specialEvents.getTag());
                         special.putLong(Const.SPECIAL_EVENT_START_EXTRA, DateTime.now().getMillis());
-                        special.putLong(Const.SPECIAL_EVENT_END_EXTRA, DATE_2015_06_01_GMT_IN_MILLIS);
-                        special.putInt(Const.SPECIAL_EVENT_DESCRIPTION_EXTRA, R.string.ioextended_description);
+                        special.putLong(Const.SPECIAL_EVENT_END_EXTRA, specialEvents.getEndDateInMillis());
+                        special.putInt(Const.SPECIAL_EVENT_DESCRIPTION_EXTRA, specialEvents.getDescriptionResId());
                         navigateTo(SpecialEventActivity.class, special);
                         break;
                     case Const.DRAWER_PULSE:

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/DrawerAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/DrawerAdapter.java
@@ -40,7 +40,7 @@ public class DrawerAdapter extends BaseAdapter {
             //add(new DrawerItem(Const.DRAWER_GDL, R.drawable.drw_ic_gdl, R.string.gdl));
             add(new DrawerItem(Const.DRAWER_GDE, R.drawable.drw_ic_gde, R.string.gde));
             add(new DrawerItem(Const.DRAWER_PULSE, R.drawable.drw_ic_pulse, R.string.pulse));
-            add(new DrawerItem(Const.DRAWER_SPECIAL, R.drawable.drw_ic_devfest, R.string.devfest));
+            add(new DrawerItem(Const.DRAWER_SPECIAL, R.drawable.drw_ic_ioextended, R.string.ioextended));
             add(new DrawerItem(Const.DRAWER_ACHIEVEMENTS, R.drawable.drw_ic_achievements, R.string.achievements));
             add(new DrawerItem(Const.DRAWER_ARROW, R.drawable.drw_ic_arrow, R.string.arrow));
         }};

--- a/app/src/main/java/org/gdg/frisbee/android/adapter/DrawerAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/adapter/DrawerAdapter.java
@@ -1,8 +1,6 @@
 package org.gdg.frisbee.android.adapter;
 
 import android.content.Context;
-import android.nfc.NfcAdapter;
-import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,14 +12,8 @@ import java.util.ArrayList;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.special.SpecialEvents;
 
-/**
- * Created with IntelliJ IDEA.
- * User: maui
- * Date: 03.07.13
- * Time: 02:50
- * To change this template use File | Settings | File Templates.
- */
 public class DrawerAdapter extends BaseAdapter {
 
     private Context mContext;
@@ -37,10 +29,10 @@ public class DrawerAdapter extends BaseAdapter {
     private void initAdapter() {
         mItems = new ArrayList<DrawerItem>() {{
             add(new DrawerItem(Const.DRAWER_HOME, R.drawable.drw_ic_home_gdg, R.string.home_gdg));
-            //add(new DrawerItem(Const.DRAWER_GDL, R.drawable.drw_ic_gdl, R.string.gdl));
             add(new DrawerItem(Const.DRAWER_GDE, R.drawable.drw_ic_gde, R.string.gde));
             add(new DrawerItem(Const.DRAWER_PULSE, R.drawable.drw_ic_pulse, R.string.pulse));
-            add(new DrawerItem(Const.DRAWER_SPECIAL, R.drawable.drw_ic_ioextended, R.string.ioextended));
+            SpecialEvents specialEvents = SpecialEvents.getCurrent();
+            add(new DrawerItem(Const.DRAWER_SPECIAL, specialEvents.getDrawerIconResId(), specialEvents.getTitleResId()));
             add(new DrawerItem(Const.DRAWER_ACHIEVEMENTS, R.drawable.drw_ic_achievements, R.string.achievements));
             add(new DrawerItem(Const.DRAWER_ARROW, R.drawable.drw_ic_arrow, R.string.arrow));
         }};

--- a/app/src/main/java/org/gdg/frisbee/android/special/SpecialEventActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/special/SpecialEventActivity.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gdg.frisbee.android.activity;
+package org.gdg.frisbee.android.special;
 
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
@@ -22,6 +22,7 @@ import android.widget.TextView;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.activity.GdgNavDrawerActivity;
 import org.gdg.frisbee.android.fragment.TaggedEventFragment;
 import org.gdg.frisbee.android.view.ResizableImageView;
 import org.joda.time.DateTime;
@@ -62,8 +63,8 @@ public class SpecialEventActivity extends GdgNavDrawerActivity {
         trans.replace(R.id.content_fragment, TaggedEventFragment.newInstance(
                 getIntent().hasExtra(Const.SPECIAL_EVENT_CACHEKEY_EXTRA) ? getIntent().getStringExtra(Const.SPECIAL_EVENT_CACHEKEY_EXTRA) : "specialevent",
                 getIntent().hasExtra(Const.SPECIAL_EVENT_VIEWTAG_EXTRA) ? getIntent().getStringExtra(Const.SPECIAL_EVENT_VIEWTAG_EXTRA) : "specialevent",
-                getIntent().getLongExtra(Const.SPECIAL_EVENT_START_EXTRA, DateTime.now().getMillis()),
-                getIntent().getLongExtra(Const.SPECIAL_EVENT_END_EXTRA, DateTime.now().getMillis() + 604800000),
+                getIntent().getLongExtra(Const.SPECIAL_EVENT_START_EXTRA, getIntent().getLongExtra(Const.SPECIAL_EVENT_END_EXTRA, DateTime.now().getMillis())),
+                getIntent().getLongExtra(Const.SPECIAL_EVENT_END_EXTRA, getIntent().getLongExtra(Const.SPECIAL_EVENT_END_EXTRA, DateTime.now().getMillis() + 604800000)),
                 getIntent().getIntExtra(Const.SPECIAL_EVENT_FRAGMENT_LAYOUT_EXTRA, R.layout.fragment_events)));
         trans.commit();
     }

--- a/app/src/main/java/org/gdg/frisbee/android/special/SpecialEvents.java
+++ b/app/src/main/java/org/gdg/frisbee/android/special/SpecialEvents.java
@@ -1,0 +1,53 @@
+package org.gdg.frisbee.android.special;
+
+import org.gdg.frisbee.android.R;
+
+public class SpecialEvents {
+    private static final long DATE_2015_06_01_GMT_IN_MILLIS = 1433116800000L;
+
+    private String mTag;
+    private int mDrawerIconResId;
+    private int mTitleResId;
+    private int mDescriptionResId;
+    private int mLogoResId;
+    private long mEndDateInMillis;
+
+
+    public SpecialEvents(String tag, int drawerIconResId, int titleResId, int descriptionResId, int logoResId, long endDateInMillis) {
+        mTag = tag;
+        mDrawerIconResId = drawerIconResId;
+        mTitleResId = titleResId;
+        mDescriptionResId = descriptionResId;
+        mLogoResId = logoResId;
+        mEndDateInMillis = endDateInMillis;
+    }
+
+    public static SpecialEvents getCurrent() {
+        return new SpecialEvents("io-extended", R.drawable.drw_ic_ioextended, R.string.ioextended, R.string.ioextended_description,
+                R.drawable.ioextended, DATE_2015_06_01_GMT_IN_MILLIS);
+    }
+
+    public String getTag() {
+        return mTag;
+    }
+
+    public int getDrawerIconResId() {
+        return mDrawerIconResId;
+    }
+
+    public int getTitleResId() {
+        return mTitleResId;
+    }
+
+    public int getDescriptionResId() {
+        return mDescriptionResId;
+    }
+
+    public int getLogoResId() {
+        return mLogoResId;
+    }
+
+    public long getEndDateInMillis() {
+        return mEndDateInMillis;
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -113,7 +113,7 @@
     <string name="order_by_distance">Ordenar por distancia</string>
     <string name="gcm_event_ticker">Un nuevo evento de su GDG principal ha sido agendado</string>
     <string name="ioextended_description">Google I/O Extended se trata de unirte a la conferencia de Google IO en tu grupo local.</string>
-    <string name="ioextended">Extended 2014</string>
+    <string name="ioextended">Extended 2015</string>
     <string name="media_route_menu_title">Cast session</string>
     <string name="navigate_to">Dirección del evento</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -115,7 +115,7 @@
     <string name="flightschool">Dart Flight School</string>
     <string name="flightschool_description">Dart 1.0\'e ulaştı ve uçuşa hazır! Geliştirici toplulukları 2014 Şubat ayı boyunca dünya çapında Dart Flight School etkinlikleri düzenliyorlar. Web geliştirme kanatlarınızı Dart ve Angular ile kazanın!</string>
     <string name="ioextended_description">Google I/O Extended etkinlikleri sayesinde yerel gruplarınız ile Google konferansına katılma deneyimi yaşarsınız.</string>
-    <string name="ioextended">Extended 2014</string>
+    <string name="ioextended">Extended 2015</string>
     <string name="media_route_menu_title">Oturumu Cast et</string>
     <string name="navigate_to">Etkiliğe yol tarifi al</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,7 @@
     <string name="flightschool">Dart Flight School</string>
     <string name="flightschool_description">Dart hit 1.0 and is now Flight Ready! Developer communities around the world are hosting Dart Flight School events during the month of February 2014. Get your web development wings with Dart and Angular!</string>
     <string name="ioextended_description">Google I/O Extended is about joining the Google conference at your local group.</string>
-    <string name="ioextended">Extended 2014</string>
+    <string name="ioextended">Extended 2015</string>
     <string name="devfest">DevFest 2014</string>
     <string name="devfest_description">GDG DevFests are large, community-run events that can offer speaker sessions across multiple product areas, all-day hack-a-thons, code labs, and more.\n\nEach GDG DevFest will be inspired by and uniquely tailored to the needs of the developer community that hosts it. While no two events will be exactly alike, each GDG DevFest will, at its core, be powered by a shared belief that when developers come together to exchange ideas, amazing things can happen.</string>
     <string name="media_route_menu_title">Cast session</string>


### PR DESCRIPTION
This PR updates the details for the special events activity. It introduces an object for these details that can be updated in the future through the hub.

In addition, it moves the activity into its own package. It also fixes the SpecialEventActivity's use of end data extra. 