### PR TITLE
Selected chapter cannot be null

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -71,7 +71,7 @@ public class Const {
     public static final String EXTRA_SECTION = "EXTRA_SECTION";
     public static final String URL_DEVELOPERS_GOOGLE_COM = "https://developers.google.com";
     public static final String EVENTS = "events";
-    public static final String EXTRA_GROUP_ID = "org.gdg.frisbee.CHAPTER";
+    public static final String EXTRA_CHAPTER_ID = "org.gdg.frisbee.CHAPTER";
     public static final String CACHE_KEY_CHAPTER_LIST_HUB = "chapter_list_hub";
 
     // Location

--- a/app/src/main/java/org/gdg/frisbee/android/activity/FirstStartActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/FirstStartActivity.java
@@ -241,8 +241,7 @@ public class FirstStartActivity extends ActionBarActivity implements FirstStartS
 
         Intent resultData = new Intent(FirstStartActivity.this, MainActivity.class);
         resultData.setAction("finish_first_start");
-        resultData.putExtra(Const.EXTRA_GROUP_ID, mSelectedChapter);
-        resultData.putExtra("selected_chapter", mSelectedChapter);
+        resultData.putExtra(Const.EXTRA_CHAPTER_ID, mSelectedChapter);
         startActivity(resultData);
 
         super.finish();

--- a/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -116,7 +115,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
                     @Override
                     public void onPutIntoCache() {
                         ArrayList<Chapter> chapters = directory.getGroups();
-                        initChapters(chapters, null);
+                        initChapters(chapters);
                     }
                 });
             }
@@ -143,7 +142,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
                 @Override
                 public void onGet(Object item) {
                     Directory directory = (Directory) item;
-                    initChapters(directory.getGroups(), null);
+                    initChapters(directory.getGroups());
                 }
 
                 @Override
@@ -191,21 +190,18 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
     }
 
     /**
-     * Initializes ViewPager, SlidingTabLayout, and Spinner Navigation. 
-     * 
-     * If the selectedChapter is null, tries to get it from Intent Extras,
-     *                                  if not found, gets the first Chapter.
-     * This function is called after cache query or network call is success,
-     * or after an orientation change using savedInstance.
-     *  
+     * Initializes ViewPager, SlidingTabLayout, and Spinner Navigation.
+     *
+     * It tries to get selected chapter from Intent Extras,
+     *                                  if not found, gets the first Chapter in the array.
+     * This function is called after cache query or network call is success
+     *
      * @param chapters Chapter array to be initialized, never null.
-     * @param selectedChapter selectedChapter, can be null.
      */
-    private void initChapters(@NonNull ArrayList<Chapter> chapters,
-                              @Nullable Chapter selectedChapter) {
-        addChapters(chapters);
+    private void initChapters(@NonNull ArrayList<Chapter> chapters) {
 
-        if (selectedChapter == null && getIntent().hasExtra(Const.EXTRA_CHAPTER_ID)) {
+        Chapter selectedChapter = null;
+        if (getIntent().hasExtra(Const.EXTRA_CHAPTER_ID)) {
             final String chapterId = getIntent().getStringExtra(Const.EXTRA_CHAPTER_ID);
             for (Chapter c : chapters) {
                 if (c.getGplusId().equals(chapterId)) {
@@ -214,10 +210,24 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
                 }
             }
         }
-        
+
         if (selectedChapter == null) {
             selectedChapter = chapters.get(0);
         }
+        initChapters(chapters, selectedChapter);
+    }
+
+    /**
+     * Initializes ViewPager, SlidingTabLayout, and Spinner Navigation.
+     * This function is called after cache query or network call is success,
+     * or after an orientation change using savedInstance.
+     *  
+     * @param chapters Chapter array to be initialized, never null.
+     * @param selectedChapter selectedChapter, never null.
+     */
+    private void initChapters(@NonNull ArrayList<Chapter> chapters,
+                              @NonNull Chapter selectedChapter) {
+        addChapters(chapters);
 
         getSupportActionBar().setSelectedNavigationItem(mSpinnerAdapter.getPosition(selectedChapter));
 
@@ -318,7 +328,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
         public ChapterFragmentPagerAdapter(Context ctx, FragmentManager fm, @NonNull Chapter selectedChapter) {
             super(fm);
             mContext = ctx;
-            this.mSelectedChapter = selectedChapter;
+            mSelectedChapter = selectedChapter;
         }
 
         @Override
@@ -366,7 +376,7 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
             if (mSelectedChapter != null) {
                 trackView();
             }
-            this.mSelectedChapter = chapter;
+            mSelectedChapter = chapter;
         }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
@@ -214,6 +214,8 @@ public class MainActivity extends GdgNavDrawerActivity implements ActionBar.OnNa
 
         if (getIntent().hasExtra(Const.EXTRA_GROUP_ID)) {
             String chapterId = getIntent().getStringExtra(Const.EXTRA_GROUP_ID);
+        if (getIntent().hasExtra(Const.EXTRA_CHAPTER_ID)) {
+            final String chapterId = getIntent().getStringExtra(Const.EXTRA_CHAPTER_ID);
             for (Chapter c : chapters) {
                 if (c.getGplusId().equals(chapterId)) {
                     chapter = c;

--- a/app/src/main/java/org/gdg/frisbee/android/activity/StartActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/StartActivity.java
@@ -44,6 +44,12 @@ public class StartActivity extends ActionBarActivity {
             intentForStart = new Intent(StartActivity.this, FirstStartActivity.class);
         } else {
             intentForStart = new Intent(StartActivity.this, MainActivity.class);
+
+            final String selectedChapterGplusId = 
+                    preferences.getString(Const.SETTINGS_HOME_GDG, null);
+            if (selectedChapterGplusId != null) {
+                intentForStart.putExtra(Const.EXTRA_CHAPTER_ID, selectedChapterGplusId);
+            }
         }
 
         startActivity(intentForStart);

--- a/app/src/main/java/org/gdg/frisbee/android/service/GcmIntentService.java
+++ b/app/src/main/java/org/gdg/frisbee/android/service/GcmIntentService.java
@@ -82,7 +82,7 @@ public class GcmIntentService extends IntentService {
                 .build());
 
         eventIntent.setClass(getApplicationContext(), EventActivity.class);
-        eventIntent.putExtra(Const.EXTRA_GROUP_ID, extras.getString("chapter"));
+        eventIntent.putExtra(Const.EXTRA_CHAPTER_ID, extras.getString("chapter"));
         eventIntent.putExtra(Const.EXTRA_EVENT_ID, extras.getString("id"));
         eventIntent.putExtra(Const.EXTRA_SECTION, EventActivity.EventPagerAdapter.SECTION_OVERVIEW);
 


### PR DESCRIPTION
- refactor: EXTRA_GROUP_ID refactored into EXTRA_CHAPTER_ID and removed unused "selected_chapter" key
- `MyAdapter` is now `ChapterFragmentPagerAdapter`
- `initChapters()` function is used everywhere to initialize the `ViewPager`. No more duplicates.
- `initChapters()` now gets selectedChapter as a variable. It is given immediately when an orientation change occurs. It can be null. When it is null, it is gotten from Intent Extra.
- `ChapterFragmentPagerAdapter` now gets selectedChapter from constructor and it cannot be null again.