### PR TITLE
Joda Time for Android by dlew is used instead of the original.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,7 +120,7 @@ dependencies {
 
     //Others
     compile 'org.jsoup:jsoup:1.7.3'
-    compile 'joda-time:joda-time:2.3'
+    compile 'net.danlew:android.joda:2.7.1'
     compile ('de.keyboardsurfer.android.widget:crouton:1.8.4') {
         exclude module: 'support-v4'
     }

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -30,12 +30,8 @@
 # Volley
 -keep class android.support.v4.app.** { *; }
 -keep interface android.support.v4.app.** { *; }
--keep class com.actionbarsherlock.** { *; }
--keep interface com.actionbarsherlock.** { *; }
 -keep class com.android.volley.** { *; }
 -keep interface com.android.volley.** { *; }
-
--keepattributes *Annotation*
 
 -dontwarn org.apache.**
 
@@ -55,12 +51,9 @@
     @com.squareup.otto.Produce public *;
 }
 
-# VPI
--keep class com.viewpagerindicator.** { *; }
--keep interface com.viewpagerindicator.** { *; }
-
 # Jodatime
 -dontwarn org.joda.convert.**
+-dontwarn org.joda.time.**
 -keep class org.joda.time.** { *; }
 -keep interface org.joda.time.** { *; }
 
@@ -79,12 +72,6 @@
 # file in the SDK. If it is, then you don't need to duplicate it. See your
 # "project.properties" file to get the path to the default "proguard-android-optimize.txt".
 -keepattributes *Annotation*
-
-# keep this class so that logging will show 'ACRA' and not a obfuscated name like 'a'.
-# Note: if you are removing log messages elsewhere in this file then this isn't necessary
--keep class org.acra.ACRA {
-    *;
-}
 
 # keep this around for some enums that ACRA needs
 -keep class org.acra.ReportingInteractionMode {

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -61,6 +61,8 @@
 
 # Jodatime
 -dontwarn org.joda.convert.**
+-keep class org.joda.time.** { *; }
+-keep interface org.joda.time.** { *; }
 
 # ButterKnife
 -dontwarn butterknife.internal.**


### PR DESCRIPTION
They say that this is better in terms of performance.
It is because it handles String resources with Android way with resources. 