### PR TITLE
Chore/Add help menu with link to google support

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -65,6 +65,7 @@ public class Const {
     public static final String EXTRA_EVENT_ID = "EXTRA_EVENT_ID";
     public static final String EXTRA_SECTION = "EXTRA_SECTION";
     public static final String URL_DEVELOPERS_GOOGLE_COM = "https://developers.google.com";
+    public static final String URL_HELP = "https://support.google.com/developergroups";
     public static final String EVENTS = "events";
     public static final String EXTRA_CHAPTER_ID = "org.gdg.frisbee.CHAPTER";
     public static final String CACHE_KEY_CHAPTER_LIST_HUB = "chapter_list_hub";

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
@@ -18,6 +18,7 @@ package org.gdg.frisbee.android.activity;
 
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
@@ -186,6 +187,9 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         switch (item.getItemId()) {
             case R.id.settings:
                 startActivity(new Intent(this, SettingsActivity.class));
+                return true;
+            case R.id.help:
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Const.URL_HELP)));
                 return true;
             case R.id.about:
                 startActivity(new Intent(this, AboutActivity.class));

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -8,6 +8,11 @@
     app:showAsAction="collapseActionView"
     android:menuCategory="secondary"/>
   <item
+    android:id="@+id/help"
+    android:title="@string/help"
+    app:showAsAction="collapseActionView"
+    android:menuCategory="secondary" />
+  <item
     android:id="@+id/about"
     android:title="@string/about"
     app:showAsAction="collapseActionView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,4 +152,5 @@
     <string name="event_info">Info</string>
     <string name="event_agenda">Agenda</string>
     <string name="event_more">More</string>
+    <string name="help">Help</string>
 </resources>


### PR DESCRIPTION
This PR adds a help menu that links to the google support page for developer groups.

![device-2015-02-24-222219](https://cloud.githubusercontent.com/assets/1449049/6359593/96660c94-bc74-11e4-91df-e4a4e6bb1139.png)
