### PR TITLE
chore: remove ACRA from 3rd party libraries

### DIFF
--- a/app/src/main/assets/third_party.html
+++ b/app/src/main/assets/third_party.html
@@ -91,23 +91,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
 See the License for the specific language governing permissions and<br/>
 limitations under the License.<br/><br/>
 
-<b>ACRA</b><br/>
-Application Crash Reporting for Android<br/>
-Copyright (c) 2013 Kevin Gaudin<br/>
-http://acra.ch<br/><br/>
-
-Licensed under the Apache License, Version 2.0 (the "License");<br/>
-you may not use this file except in compliance with the License.<br/>
-You may obtain a copy of the License at<br/><br/>
-
-http://www.apache.org/licenses/LICENSE-2.0<br/><br/>
-
-Unless required by applicable law or agreed to in writing, software<br/>
-distributed under the License is distributed on an "AS IS" BASIS,<br/>
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
-See the License for the specific language governing permissions and<br/>
-limitations under the License.<br/><br/>
-
 <b>Crouton</b><br/>
 Copyright 2012 - 2013 Benjamin Weiss<br/><br/>
 


### PR DESCRIPTION
ACRA was replaced with Crashlytics.