### PR TITLE
about_tabs are removed on other languages.

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">včera</item>
         <item quantity="other">před %d dny</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>O aplikaci</item>
-        <item>Borci</item>
-        <item>Seznam změn</item>
-        <item>Zapoj se</item>
-        <item>Knihovny třetích stran</item>
-    </string-array>
     <string name="contributors">GDG appka je vytvořena komunitou a je open-source. Tito lidé přispěli:</string>
     <string name="get_involved">Zapoj se!</string>
     <string name="get_involved_text">GDG appka je vytvořena komunitou a je open-source. Každý se může zapojit a rozvíjet appku.\n\nProstě běž na GitHub a stáhni si kód.\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -65,14 +65,6 @@
         <item quantity="one">vor einem Tag</item>
         <item quantity="other">vor %d Tagen</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>Über</item>
-        <item>Entwickler</item>
-        <item>Übersetzer</item>
-        <item>Änderungen</item>
-        <item>Mach mit</item>
-        <item>Drittlizenzen</item>
-    </string-array>
     <string name="contributors">Die GDG App ist Open Source. Folgende Personen sind an der Entwicklung beteiligt:</string>
     <string name="get_involved">Mach mit!</string>
     <string name="get_involved_text">Die GDG App ist Open Source. Wir freuen uns über jeden der uns bei der Entwicklung unterstützen möchte.\n\nGehe zu GitHub uns sehe dir unseren Code an.\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">hace 1 día</item>
         <item quantity="other">hace %d días</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>Acerca de</item>
-        <item>Colaboradores</item>
-        <item>Cambios</item>
-        <item>Colaborar</item>
-        <item>3rd Party Libraries</item>
-    </string-array>
     <string name="contributors">La aplicación de GDG es un esfuerzo comunitario y de código abierto -del ingles "open source"-. Estas son algunas de las personas que colaboraron con la aplicación:</string>
     <string name="get_involved">Colabora!</string>
     <string name="get_involved_text">La aplicación de GDG es un esfuerzo comunitario y de código abierto. Todos son bienvenidos a participar y mejorar esta aplicacion.\n\nSolo diríjanse a GitHub y bájense el código.\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,13 +66,6 @@
     <item quantity="one">il y a un jour</item>
     <item quantity="other">il y a %d jours</item>
   </plurals>
-  <string-array name="about_tabs">
-    <item>À propos</item>
-    <item>Contributeurs</item>
-    <item>Modifications</item>
-    <item>Contribuer</item>
-    <item>Bibliothèques utilisées</item>
-  </string-array>
   <string name="contributors">L\'application GDG est un effort communautaire et open source. Les personnes suivantes ont
     contribué à l\'application:
   </string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">1 दिन पहले</item>
         <item quantity="other">%d दिन पहले</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>एप्प के बारे में</item>
-        <item>सहयोगी</item>
-        <item>परिवर्तन दैनिकी</item>
-        <item>शामिल होँ</item>
-        <item>मुक्त स्रोत  Libraries</item>
-    </string-array>
     <string name="contributors">यह जी डी जी एप्प सामुदायिक प्रयास है और इसका स्रोत मुक्त रूप से उपलब्ध है। निम्न लोगों ने इस एप्प में अपना सहयोग प्रदान किया है :</string>
     <string name="get_involved">शामिल होँ!</string>
     <string name="get_involved_text">यह जी डी जी एप्प सामुदायिक प्रयास है और इसका स्रोत मुक्त रूप से उपलब्ध है। आप सभी आमंत्रित हैं इस एप्प को बेहतर बनाने में। \n\nबस GitHub पर जाएँ और एप्प के स्रोत को हासिल करें।\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">"1일 전"</item>
         <item quantity="other">"%d 일 전"</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>"정보"</item>
-        <item>"도움 주신 분들"</item>
-        <item>"변경사항"</item>
-        <item>"참여하기"</item>
-        <item>"오픈소스 라이브러리"</item>
-    </string-array>
     <string name="contributors">"GDG 앱은 커뮤니티의 노력으로 만들어졌으면 오픈소스로 공개되어 있습니다. 아래의 분들이 앱에 기여해 주셨습니다."</string>
     <string name="get_involved">"참여하기!"</string>
     <string name="get_involved_text">"GDG 앱은 커뮤니티의 노력으로 만들어졌으면 오픈소스로 공개되어 있습니다.  이 앱의 개발과 개선에는 누구나 참여할 수 있습니다.\n\n소스코드는 Github에서 체크 아웃할 수 있습니다.\n\nhttps://github.com/gdg-x"</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">prieš dieną</item>
         <item quantity="other">prieš %d dienas</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>Apie</item>
-        <item>Dalyviai</item>
-        <item>Pakeitimų žurnalas</item>
-        <item>Prisijunk</item>
-        <item>Trečios šalies bibliotekos</item>
-    </string-array>
     <string name="contributors">GDG programėlė yra atvirojo kodo. Štai šie žmonės prisidėjo:</string>
     <string name="get_involved">Prisijunk ir Tu!</string>
     <string name="get_involved_text">GDG programėlė yra atvirojo kodo. Visi yra kviečiami prisijungti ir patobulinti šią programėlę.\n\nTiesiog atsidarykite GitHub ir parsisiųskite kodą.\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">1 dag geleden</item>
         <item quantity="other">%d dagen geleden</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>Over</item>
-        <item>Bijdragers</item>
-        <item>Changelog</item>
-        <item>Meedoen</item>
-        <item>3rd Party Bibliotheken</item>
-    </string-array>
     <string name="contributors">De GDG app is een community moeite en open sourced. De volgende personen hebben eraan meegewerkt:</string>
     <string name="get_involved">Meedoen!</string>
     <string name="get_involved_text">De GDG app is een community moeite en open sourced. Iedereen is uitgenodigd om eraan meetewerken en deze app te verbeteren.\n\nGa naar GitHub en checkout onze code.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -67,13 +67,6 @@
         <item quantity="one">1 dzień wcześniej</item>
         <item quantity="other">%d dni wcześniej</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>O aplikacji</item>
-        <item>Twórcy</item>
-        <item>Zmiany</item>
-        <item>Wesprzyj nas</item>
-        <item>Użyte biblioteki</item>
-    </string-array>
     <string name="contributors">Aplikacja GDG jest rozwijana przez społeczność na zasadach open source. W jej tworzeniu brały udział następujące osoby:</string>
     <string name="get_involved">Wesprzyj nas!</string>
     <string name="get_involved_text">Aplikacja GDG jest projektem rozwijanym przez społeczność na zasadach open source. Każdy udział i każda pomoc w rozwoju aplikacji jest mile widziana.\n\nOdwiedź stronę projektu na GitHub i uzyskaj dostęp do kodu aplikacji.\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -62,13 +62,6 @@
         <item quantity="one">"1 dia atrás"</item>
         <item quantity="other">"%d dias atrás"</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>"Sobre"</item>
-        <item>"Colaboradores"</item>
-        <item>"Changelog"</item>
-        <item>"Participe"</item>
-        <item>"Bibliotecas de Terceiros"</item>
-    </string-array>
     <string name="contributors">"O app GDG é um esforço da comunidade e possui código aberto. As seguintes pessoas contribuíram para o app:"</string>
     <string name="get_involved">"Envolva-se"</string>
     <string name="get_involved_text">"O app GDG é um esforço da comunidade e possui código aberto. Todos estão convidados a participar e melhorar este app. \n\nVisite o GitHub e faça o checkout do nosso código."</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">1 день назад</item>
         <item quantity="other">%d дней назад</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>О приложении</item>
-        <item>Разработчики</item>
-        <item>Изменения</item>
-        <item>Прими участие</item>
-        <item>Сторонние библиотеки</item>
-    </string-array>
     <string name="contributors">Приложение GDG создано усилиями сообщества и имеет открытый исходный код. Следуюшие разработчики приняли участие в создании приложения:</string>
     <string name="get_involved">Прими участие!</string>
     <string name="get_involved_text">Приложение GDG создано усилиями сообщества и имеет открытый исходный код. Все желающие могут участвовать и улучшать это приложение.\n\nОтправляйтесь на GitHub и сделайте checkout нашего кода.\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">pred 1 dňom</item>
         <item quantity="other">pred %d dňami</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>O aplikácii</item>
-        <item>Autori</item>
-        <item>Zoznam zmien</item>
-        <item>Zapoj sa</item>
-        <item>Knižnice tretích strán</item>
-    </string-array>
     <string name="contributors">GDG aplikácia je komunitný projekt a je open source. Tímto ľudom vďačíme za jej funkčnosť:</string>
     <string name="get_involved">Zapoj sa!</string>
     <string name="get_involved_text">GDG aplikácia je komunitný projekt a je open source. Každý môže prispieť do jej vývoja. \n\nChoď na GitHub a sťahuj kód. \n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">1 วันที่ผ่านมา</item>
         <item quantity="other">%d วันที่ผ่านมา</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>เกี่ยวกับ</item>
-        <item>ผู้มีส่วนช่วย</item>
-        <item>ข้อมูลการเปลี่ยนแปลง</item>
-        <item>เข้าร่วมกับเรา</item>
-        <item>ไลบรารีอื่นๆ</item>
-    </string-array>
     <string name="contributors">แอพพลิเคชัน GDG เป็นผลงานส่วนหนึ่งของชุมชนนักพัฒนา โดยเปิดให้มีการเข้าถึงที่มาและยำไปใช้ได้โดยเสรี(Open source) โดยบุคคลเหล่านี้คือผู้ที่มีส่วนช่วยในการพัฒนา:</string>
     <string name="get_involved">เข้าร่วมกับเรา</string>
     <string name="get_involved_text">แอพพลิเคชัน GDG  เป็นผลงานส่วนหนึ่งของชุมชนนักพัฒนา โดยเปิดให้มีการเข้าถึงที่มาและยำไปใช้ได้โดยเสรี(Open source) ทุกคนสามารถร่วมเป็นส่วนหนึ่งในการเข้าร่วมและพัฒนาแอพพลิเคชันนี้ เพียงไปที่ Github แล้ว checkout ซอร์สโค้ดจาก \n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">1 gün önce</item>
         <item quantity="other">%d gün önce</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>Hakkında</item>
-        <item>Katkıda Bulunanlar</item>
-        <item>Change Log</item>
-        <item>Dahil Ol</item>
-        <item>3. Parti Kütüphaneler</item>
-    </string-array>
     <string name="contributors">GDG uygulaması açık kaynaklıdır ve topluluk çabalarıyla geliştirilmektedir. Katkıda bulunan kişiler aşağıda:</string>
     <string name="get_involved">Dahil Ol!</string>
     <string name="get_involved_text">GDG uygulaması açık kaynaklıdır ve topluluk çabalarıyla geliştirilmektedir. Herkes uygulamaya dahil olabilir ve gelişmesine katkıda bulunabilir.\n\nBunun için GitHub\'ı açın ve kodumuzu checkout edin.\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -68,13 +68,6 @@
         <item quantity="one">1 день тому</item>
         <item quantity="other">%d днів тому</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>Про програму</item>
-        <item>Розробники</item>
-        <item>Зміни</item>
-        <item>Долучитися</item>
-        <item>Сторонні бібліотеки</item>
-    </string-array>
     <string name="contributors">GDG додаток є результатом колективної роботи з відкритим кодом.
         Наступні люди внесли свій внесок у програму:
     </string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -64,13 +64,6 @@
         <item quantity="one">1 天前</item>
         <item quantity="other">%d 天前</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>关于</item>
-        <item>贡献者</item>
-        <item>修改记录</item>
-        <item>参与贡献</item>
-        <item>第三方库</item>
-    </string-array>
     <string name="contributors">本 GDG  应用程序为社区贡献并开源。以下为贡献者：</string>
     <string name="get_involved">参与贡献！</string>
     <string name="get_involved_text">本 GDG 应用程序为社区开发，任何人都欢迎参与到开发中。\n\n请直接前往 Github 获取代码。\n\nhttps://github.com/imstand/GDG-China</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">1 天前</item>
         <item quantity="other">%d 天前</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>關於</item>
-        <item>貢獻者</item>
-        <item>修改記錄</item>
-        <item>參與貢獻</item>
-        <item>第三方庫</item>
-    </string-array>
     <string name="contributors">本 GDG 應用程式為社群貢獻的成果並開放原始碼。以下為參與貢獻的人士：</string>
     <string name="get_involved">參與貢獻！</string>
     <string name="get_involved_text">本 GDG 應用程式為社群貢獻的成果並開放原始碼，任何人都歡迎參與編修及改善本應用程式。\n\n請直接前往 Github 提取代碼。\n\nhttps://github.com/gdg-x</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -65,13 +65,6 @@
         <item quantity="one">1 天前</item>
         <item quantity="other">%d 天前</item>
     </plurals>
-    <string-array name="about_tabs">
-        <item>關於</item>
-        <item>貢獻者</item>
-        <item>修改記錄</item>
-        <item>參與貢獻</item>
-        <item>第三方庫</item>
-    </string-array>
     <string name="contributors">本 GDG 應用程式為社群貢獻的成果並開放原始碼。以下為參與貢獻的人士：</string>
     <string name="get_involved">參與貢獻！</string>
     <string name="get_involved_text">本 GDG 應用程式為社群貢獻的成果並開放原始碼，任何人都歡迎參與編修及改善本應用程式。\n\n請直接前往 Github 提取代碼。\n\nhttps://github.com/gdg-x</string>


### PR DESCRIPTION
This is one of the lint errors. about_tabs should contain 6 items but all of these include 5.