### PR TITLE
chore: remove Joda-Time from 3rd party libraries

### DIFF
--- a/app/src/main/assets/third_party.html
+++ b/app/src/main/assets/third_party.html
@@ -75,22 +75,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
 See the License for the specific language governing permissions and<br/>
 limitations under the License.<br/><br/>
 
-<b>Joda-Time</b><br/>
-This product includes software developed by<br/>
-Joda.org (http://www.joda.org/).<br/><br/>
-
-Licensed under the Apache License, Version 2.0 (the "License");<br/>
-you may not use this file except in compliance with the License.<br/>
-You may obtain a copy of the License at<br/><br/>
-
-http://www.apache.org/licenses/LICENSE-2.0<br/><br/>
-
-Unless required by applicable law or agreed to in writing, software<br/>
-distributed under the License is distributed on an "AS IS" BASIS,<br/>
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
-See the License for the specific language governing permissions and<br/>
-limitations under the License.<br/><br/>
-
 <b>Joda-Time-Android</b><br/>
 Copyright 2014 - Dan Lew<br/><br/>
         


### PR DESCRIPTION
Joda-Time was removed but it was left in the list of 3rd party libraries.