### PR TITLE
disable ListPreferences when no data available, fixes #281

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -204,8 +204,7 @@ public class SettingsFragment extends PreferenceFragment {
     private void initPreferences() {
         final ListPreference prefHomeGdgList = (ListPreference) findPreference(PrefUtils.SETTINGS_HOME_GDG);
         if (prefHomeGdgList != null) {
-            prefHomeGdgList.setEntries(new String[0]);
-            prefHomeGdgList.setEntryValues(new String[0]);
+            prefHomeGdgList.setEnabled(false);
 
             App.getInstance().getModelCache().getAsync("chapter_list_hub", false, new ModelCache.CacheListener() {
                 @Override
@@ -223,6 +222,7 @@ public class SettingsFragment extends PreferenceFragment {
                     }
                     prefHomeGdgList.setEntries(entries);
                     prefHomeGdgList.setEntryValues(entryValues);
+                    prefHomeGdgList.setEnabled(true);
                 }
 
                 @Override

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -204,6 +204,9 @@ public class SettingsFragment extends PreferenceFragment {
     private void initPreferences() {
         final ListPreference prefHomeGdgList = (ListPreference) findPreference(PrefUtils.SETTINGS_HOME_GDG);
         if (prefHomeGdgList != null) {
+            prefHomeGdgList.setEntries(new String[0]);
+            prefHomeGdgList.setEntryValues(new String[0]);
+
             App.getInstance().getModelCache().getAsync("chapter_list_hub", false, new ModelCache.CacheListener() {
                 @Override
                 public void onGet(Object item) {


### PR DESCRIPTION
**Problem**
App crashes when user selects Home GDG preference before the list of data has been loaded asynchronously.

**Solution**
Disable uninitalized ListPreferneces