### PR TITLE
My proposal to fix #298

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
@@ -79,7 +79,10 @@ public class GdeActivity extends GdgNavDrawerActivity {
         }, new Response.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
-                Crouton.makeText(GdeActivity.this, getString(R.string.fetch_gde_failed), Style.ALERT).show();
+                try {
+                    Crouton.makeText(GdeActivity.this, R.string.fetch_gde_failed, Style.ALERT).show();
+                } catch (IllegalStateException exception) {
+                }
                 Timber.e("Could'nt fetch GDE list", volleyError);
             }
         });

--- a/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
@@ -130,7 +130,10 @@ public class MainActivity extends GdgNavDrawerActivity {
         }, new Response.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
-                Crouton.makeText(MainActivity.this, getString(R.string.fetch_chapters_failed), Style.ALERT).show();
+                try {
+                    Crouton.makeText(MainActivity.this, R.string.fetch_chapters_failed, Style.ALERT).show();
+                } catch (IllegalStateException exception) {
+                }
                 Timber.e("Couldn't fetch chapter list", volleyError);
             }
         });

--- a/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
@@ -103,7 +103,10 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
                 }, new Response.ErrorListener() {
                     @Override
                     public void onErrorResponse(VolleyError volleyError) {
-                        Crouton.makeText(PulseActivity.this, getString(R.string.fetch_chapters_failed), Style.ALERT).show();
+                        try {
+                            Crouton.makeText(PulseActivity.this, R.string.fetch_chapters_failed, Style.ALERT).show();
+                        } catch (IllegalStateException exception) {
+                        }
                         Timber.e("Couldn't fetch chapter list", volleyError);
                     }
                 }

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/FirstStartStep1Fragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/FirstStartStep1Fragment.java
@@ -105,10 +105,10 @@ public class FirstStartStep1Fragment extends Fragment {
         }, new Response.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
-                if (isDetached()) {
+                try {
+                    Crouton.makeText(getActivity(), R.string.fetch_chapters_failed, Style.ALERT).show();
+                } catch (IllegalStateException exception) {
                     Toast.makeText(getActivity(), R.string.fetch_chapters_failed, Toast.LENGTH_SHORT).show();
-                } else {
-                    Crouton.makeText(getActivity(), getString(R.string.fetch_chapters_failed), Style.ALERT).show();
                 }
                 Timber.e("Could'nt fetch chapter list", volleyError);
             }


### PR DESCRIPTION
The old code with the crash #298 is like this

```
                if (isDetached()) {
	                 Toast.makeText(getActivity(), R.string.fetch_chapters_failed, Toast.LENGTH_SHORT).show();
                } else {		
                    Crouton.makeText(getActivity(), getString(R.string.fetch_chapters_failed), Style.ALERT).show();		
                 }
```

Crash happens with the `getString` function there. In order that to happen, `isDetached()` should be false meaning that the Fragment is Attached. But the crash says that the fragment is not attached. Damn Fragments!!!

I don't know a permanent solution to this. It is a pain. Whatever you do, you will always have these issues. And they are almost always happen when the user exits the app, without waiting the response (which is obviously fine). 

I would wrap with `try-catch`s all the Crouton's