### PR TITLE
Update versions plugin to 0.8, move dep to maven/jcenter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
-apply plugin: 'versions'
 apply plugin: 'play'
 apply plugin: 'checkstyle'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,17 @@ buildscript {
         maven {
             url "http://m2-gdgx.cloud.gdgx.io/m2/"
         }
-        maven { url "https://github.com/ben-manes/gradle-versions-plugin/raw/mvnrepo" }
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.1.0'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.5-beta-2'
         classpath 'io.fabric.tools:gradle:1.14.4'
         classpath 'com.github.triplet.gradle:play-publisher:1.0.2'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.8'
     }
 }
+
+apply plugin: 'com.github.ben-manes.versions'
 
 allprojects {
     repositories {
@@ -27,7 +28,6 @@ allprojects {
         maven {
             url "http://m2-gdgx.cloud.gdgx.io/m2/"
         }
-        maven { url "https://github.com/ben-manes/gradle-versions-plugin/raw/mvnrepo" }
         maven { url 'https://maven.fabric.io/public' }
     }
 


### PR DESCRIPTION
`./gradlew dependencyUpdates -Drevision=release` allows every project contributor to easily generate a report like this

```
------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------
                                  
The following dependencies are using the latest milestone version:
 - com.android.support:appcompat-v7:21.0.3
 - com.android.support:cardview-v7:21.0.3
 - com.android.support:mediarouter-v7:21.0.3
 - com.android.support:recyclerview-v7:21.0.3
 - com.android.support:support-v4:21.0.3
 - com.android.support.test:testing-support-lib:0.1
 - com.android.support.test.espresso:espresso-core:2.0
 - com.github.ben-manes:gradle-versions-plugin:0.8
 - com.github.triplet.gradle:play-publisher:1.0.2
 - com.google:volley:4.3          
 - com.google.android.apps.dashclock:dashclock-api:2.0.0
 - com.google.android.gms:play-services-appstate:6.5.87
 - com.google.android.gms:play-services-games:6.5.87
 - com.google.android.gms:play-services-identity:6.5.87
 - com.google.android.gms:play-services-location:6.5.87
 - com.google.android.gms:play-services-plus:6.5.87
 - com.jakewharton:butterknife:6.1.0
 - com.jakewharton:disklrucache:2.0.2
 - com.jakewharton.sdkmanager:gradle-plugin:0.12.0
 - com.squareup:otto:1.3.6        
 - com.squareup.okhttp:okhttp:2.2.0
 - com.squareup.okhttp:okhttp-urlconnection:2.2.0
 - com.squareup.okio:okio:1.2.0   
 - com.squareup.picasso:picasso:2.5.0
 - junit:junit:4.12               
 - net.danlew:android.joda:2.7.1  
                                  
The following dependencies have later milestone versions:
 - com.android.tools.build:gradle [1.1.0 -> 1.1.3]
 - com.crashlytics.sdk.android:crashlytics [2.2.0 -> 2.2.2]
 - com.google.api-client:google-api-client-android [1.18.0-rc -> 1.19.1]
 - com.google.apis:google-api-services-plus [v1-rev126-1.18.0-rc -> v1-rev213-1.19.1]
 - com.google.apis:google-api-services-youtube [v3-rev106-1.18.0-rc -> v3-rev129-1.19.1]
 - com.google.code.findbugs:jsr305 [2.0.1 -> 3.0.0]
 - com.google.code.gson:gson [2.3 -> 2.3.1]
 - com.google.http-client:google-http-client-gson [1.18.0-rc -> 1.19.0]
 - com.google.zxing:android-integration [3.1.0 -> 3.2.0]
 - com.google.zxing:core [3.1.0 -> 3.2.0]
 - com.jakewharton.timber:timber [2.5.1 -> 2.7.1]
 - de.keyboardsurfer.android.widget:crouton [1.8.4 -> 1.8.5]
 - io.fabric.tools:gradle [1.14.4 -> 1.15.2]
 - org.jsoup:jsoup [1.7.3 -> 1.8.1]
                                  
Generated report file build/dependencyUpdates/report.txt
                                  
BUILD SUCCESSFUL
```

The plugin existed in an earlier version but it was released to maven in the mean time and received some updates. This allows us to remove the custom repositories for that plugin.
