### PR TITLE
fix: padding issue

### DIFF
--- a/app/src/main/res/layout/fragment_changelog.xml
+++ b/app/src/main/res/layout/fragment_changelog.xml
@@ -26,7 +26,8 @@
         <TextView
           android:id="@+id/changelog"
           android:layout_width="wrap_content"
-          android:layout_height="wrap_content" />
+          android:layout_height="wrap_content"
+          android:padding="10dip"/>
       </android.support.v7.widget.CardView>
     </LinearLayout>
   </ScrollView>

--- a/app/src/main/res/layout/fragment_chapter_info.xml
+++ b/app/src/main/res/layout/fragment_chapter_info.xml
@@ -71,7 +71,8 @@
           android:layout_height="match_parent"
           android:layout_gravity="center"
           android:layout_marginBottom="10dip"
-          android:orientation="vertical">
+          android:orientation="vertical"
+          android:padding="10dip">
 
           <TextView
             android:id="@+id/about"

--- a/app/src/main/res/layout/fragment_get_involved.xml
+++ b/app/src/main/res/layout/fragment_get_involved.xml
@@ -28,7 +28,8 @@
         <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          android:orientation="vertical">
+          android:orientation="vertical"
+          android:padding="10dip">
 
           <TextView
             android:id="@+id/textView"


### PR DESCRIPTION
1) Fix: padding issue in details box.

![screenshot_2015-03-18-15-50-08](https://cloud.githubusercontent.com/assets/888080/6707813/a9cb2274-cd90-11e4-910a-108f205a36ff.png)

2) Fix: padding issue in change log details textview
![screenshot_2015-03-18-16-00-31](https://cloud.githubusercontent.com/assets/888080/6708205/43a0a1e6-cd94-11e4-85c4-fa9283d1ae4c.png)

3) Fix: padding issue in get involved details layout
![screenshot_2015-03-18-16-00-34](https://cloud.githubusercontent.com/assets/888080/6708226/59d6074e-cd94-11e4-8f5c-fc676d7f2a89.png)

