### PR TITLE
fix: Navigation drawer close issue

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
@@ -230,6 +230,25 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         maybeUpdateChapterImage();
     }
 
+    @Override
+    public void onBackPressed() {
+        if (isNavDrawerOpen()) {
+            closeNavDrawer();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    protected boolean isNavDrawerOpen() {
+        return mDrawerLayout != null && mDrawerLayout.isDrawerOpen(Gravity.START);
+    }
+
+    protected void closeNavDrawer() {
+        if (mDrawerLayout != null) {
+            mDrawerLayout.closeDrawer(Gravity.START);
+        }
+    }
+
     private void maybeUpdateChapterImage() {
         final String homeChapterId = getCurrentHomeChapterId();
         if (isHomeChapterOutdated(homeChapterId)) {


### PR DESCRIPTION
Issue:
When the navigation drawer is open and if you press back key, It closes the application (if home screen) or goes back to the previous screen.

Fix: 
Navigation drawer should be closed on back key press. I have included close navigation drawer code inside the onBackPressed() of GdgNavDrawerActivity, as it's a base activity.