### PR TITLE
fix: ioextended tag was wrong.

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgXHub.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgXHub.java
@@ -29,7 +29,7 @@ public interface GdgXHub {
     void getEventDetail(@Path("id") String eventId,
                         Callback<EventFullDetails> callback);
 
-    @GET("/events/tag/{tag}/upcoming?perPage=1000")
+    @GET("/events/tag/{tag}/upcoming?perpage=-1")
     void getTaggedEventUpcomingList(@Path("tag") String tag,
                                     @Query("_") DateTime now,
                                     Callback<PagedList<TaggedEvent>> callback);

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -167,7 +167,7 @@ public class App extends Application implements LocationListener {
         //Add IO Extended
         addTaggedEventSeriesIfDateFits(new TaggedEventSeries(this,
                 R.style.Theme_GDG_Special_IOExtended,
-                "io-extended",
+                "ioextended",
                 Const.START_TIME_IOEXTENDED,
                 Const.END_TIME_IOEXTENDED));
     }


### PR DESCRIPTION
IO Extended section is not working and will not work when it is enabled. We should update the app before May 1st. 

perPage was not working and returning default 25 events. it should be small letters perpage. And appearantly -1 returns all the results