### PR TITLE
fix: IO Extended tag is updated again

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -167,7 +167,7 @@ public class App extends Application implements LocationListener {
         //Add IO Extended
         addTaggedEventSeriesIfDateFits(new TaggedEventSeries(this,
                 R.style.Theme_GDG_Special_IOExtended,
-                "ioextended",
+                "i-oextended",
                 Const.START_TIME_IOEXTENDED,
                 Const.END_TIME_IOEXTENDED));
     }


### PR DESCRIPTION
There are more events with "i-oextended" tag.