### PR TITLE
experiment: disable warnings on Travis.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,7 @@ android {
         abortOnError true
         checkReleaseBuilds false
 
+        ignoreWarnings isTravis
         textReport true
         textOutput 'stdout'
 


### PR DESCRIPTION
I saw this `textOutput 'stdout'` in Jake Wharton's U2020 app. While it is useful in Travis, it outputs huge number of warnings in Travis. So I disabled warnings on Travis to clearly see errors on Travis. Does it make sense?