### PR TITLE
Fix/Model cache for ArrayList

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -83,8 +83,8 @@ public class Const {
     public static final String EXTRA_CHAPTER_ID = "org.gdg.frisbee.CHAPTER";
     public static final String CACHE_KEY_CHAPTER_LIST_HUB = "chapter_list_hub";
     public static final String CACHE_KEY_PULSE_GLOBAL = "pulse_global";
-    public static final String CACHE_KEY_GDE_MAP = "gde_map";
-    public static final String CACHE_KEY_FRISBEE_CONTRIBUTORS = "frisbee_contributors";
+    public static final String CACHE_KEY_GDE_LIST = "gde_list";
+    public static final String CACHE_KEY_FRISBEE_CONTRIBUTORS = "frisbee_contributor_list";
     public static final String CACHE_KEY_PERSON = "person_";
     public static final String CACHE_KEY_NEWS = "news_";
     public static final String CACHE_KEY_PULSE = "pulse_";

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
@@ -64,7 +64,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
         mViewPagerAdapter = new GdeCategoryAdapter(getSupportFragmentManager());
 
 
-        App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_GDE_MAP, new ModelCache.CacheListener() {
+        App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_GDE_LIST, new ModelCache.CacheListener() {
             @Override
             public void onGet(Object item) {
                 GdeList directory = (GdeList) item;
@@ -88,7 +88,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
         gdeDirectoryClient.getDirectory(new Callback<GdeList>() {
             @Override
             public void success(final GdeList directory, retrofit.client.Response response) {
-                App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_GDE_MAP,
+                App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_GDE_LIST,
                         directory,
                         DateTime.now().plusDays(4),
                         new ModelCache.CachePutListener() {

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
@@ -15,6 +15,7 @@ import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.api.GdeDirectory;
 import org.gdg.frisbee.android.api.model.Gde;
+import org.gdg.frisbee.android.api.model.GdeList;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.fragment.GdeListFragment;
@@ -24,7 +25,6 @@ import org.gdg.frisbee.android.widget.SlidingTabLayout;
 import org.joda.time.DateTime;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -67,7 +67,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
         App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_GDE_MAP, new ModelCache.CacheListener() {
             @Override
             public void onGet(Object item) {
-                ArrayList<Gde> directory = (ArrayList<Gde>) item;
+                GdeList directory = (GdeList) item;
                 addGdes(directory);
             }
 
@@ -85,9 +85,9 @@ public class GdeActivity extends GdgNavDrawerActivity {
                 .setConverter(new GsonConverter(Utils.getGson(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)))
                 .build().create(GdeDirectory.class);
         
-        gdeDirectoryClient.getDirectory(new Callback<ArrayList<Gde>>() {
+        gdeDirectoryClient.getDirectory(new Callback<GdeList>() {
             @Override
-            public void success(final ArrayList<Gde> directory, retrofit.client.Response response) {
+            public void success(final GdeList directory, retrofit.client.Response response) {
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_GDE_MAP,
                         directory,
                         DateTime.now().plusDays(4),
@@ -111,15 +111,15 @@ public class GdeActivity extends GdgNavDrawerActivity {
         });
     }
 
-    private void addGdes(final ArrayList<Gde> directory) {
+    private void addGdes(final GdeList directory) {
         mHandler.post(new Runnable() {
             @Override
             public void run() {
-                HashMap<String, ArrayList<Gde>> gdeMap = new HashMap<>();
+                HashMap<String, GdeList> gdeMap = new HashMap<>();
 
                 for (Gde gde : directory) {
                     if (!gdeMap.containsKey(gde.getProduct())) {
-                        gdeMap.put(gde.getProduct(), new ArrayList<Gde>());
+                        gdeMap.put(gde.getProduct(), new GdeList());
                     }
 
                     gdeMap.get(gde.getProduct()).add(gde);
@@ -140,14 +140,14 @@ public class GdeActivity extends GdgNavDrawerActivity {
 
     public class GdeCategoryAdapter extends FragmentStatePagerAdapter implements ViewPager.OnPageChangeListener {
         private final SparseArray<WeakReference<Fragment>> mFragments = new SparseArray<>();
-        private HashMap<String, ArrayList<Gde>> mGdeMap;
+        private HashMap<String, GdeList> mGdeMap;
 
         public GdeCategoryAdapter(FragmentManager fm) {
             super(fm);
             mGdeMap = new HashMap<>();
         }
 
-        public void addMap(Map<String, ArrayList<Gde>> collection) {
+        public void addMap(Map<String, GdeList> collection) {
             mGdeMap.putAll(collection);
         }
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectory.java
@@ -1,8 +1,6 @@
 package org.gdg.frisbee.android.api;
 
-import org.gdg.frisbee.android.api.model.Gde;
-
-import java.util.ArrayList;
+import org.gdg.frisbee.android.api.model.GdeList;
 
 import retrofit.Callback;
 import retrofit.http.GET;
@@ -10,5 +8,5 @@ import retrofit.http.GET;
 public interface GdeDirectory {
     
     @GET("/gde/list")
-    void getDirectory(Callback<ArrayList<Gde>> callback);
+    void getDirectory(Callback<GdeList> callback);
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
@@ -16,9 +16,7 @@
 
 package org.gdg.frisbee.android.api;
 
-import org.gdg.frisbee.android.api.model.Contributor;
-
-import java.util.ArrayList;
+import org.gdg.frisbee.android.api.model.ContributorList;
 
 import retrofit.Callback;
 import retrofit.http.GET;
@@ -29,7 +27,7 @@ public interface GitHub {
     @GET("/repos/{owner}/{repo}/contributors")
     void getContributors(@Path("owner") String user, 
                          @Path("repo") String repo,
-                         Callback<ArrayList<Contributor>> callback);
+                         Callback<ContributorList> callback);
 
 //    @GET("/users/{username}")
 //    void getUserDetail(@Path("username") String username, Callback<EventFullDetails> callback);

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/ContributorList.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/ContributorList.java
@@ -1,0 +1,6 @@
+package org.gdg.frisbee.android.api.model;
+
+import java.util.ArrayList;
+
+public class ContributorList extends ArrayList<Contributor> {
+}

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/GdeList.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/GdeList.java
@@ -1,0 +1,6 @@
+package org.gdg.frisbee.android.api.model;
+
+import java.util.ArrayList;
+
+public class GdeList extends ArrayList<Gde> {
+}

--- a/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
+++ b/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
@@ -579,30 +579,6 @@ public class ModelCache {
             } catch (ClassNotFoundException e) {
                 e.printStackTrace();
             }
-        } else if (className.startsWith("java.util.HashMap<")) {
-            String[] inner = className.substring("java.util.HashMap<".length(), className.length() - 1).split(", ");
-
-            try {
-                Class keyClass = Class.forName(inner[0]);
-
-                Class valueClass = null;
-                if (inner[1].startsWith("java.util.ArrayList<")) {
-                    String innterT = inner[1].substring("java.util.ArrayList<".length(), inner[1].length() - 1);
-                    try {
-                        Class innerClass = Class.forName(innterT);
-                        Type t3 = TypeToken.get(Utils.createListOfType(innerClass).getClass()).getType();
-                        valueClass = (Class) t3;
-                    } catch (ClassNotFoundException e) {
-                        e.printStackTrace();
-                    }
-                } else {
-                    valueClass = Class.forName(inner[1]);
-                }
-
-                type = TypeToken.get(Utils.createMapOfType(keyClass, valueClass).getClass()).getType();
-            } catch (ClassNotFoundException e) {
-                e.printStackTrace();
-            }
         }
 
         String line = null;

--- a/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
+++ b/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
@@ -47,6 +47,7 @@ import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -527,7 +528,7 @@ public class ModelCache {
 
         BufferedWriter out = new BufferedWriter(new OutputStreamWriter(os));
 
-        String className = o.getClass().getCanonicalName();
+        String className = getClassName(o);
 
         out.write(className + "\n");
 
@@ -539,6 +540,18 @@ public class ModelCache {
         }
 
         out.close();
+    }
+
+    private String getClassName(Object o) {
+        final String canonicalName = o.getClass().getCanonicalName();
+        if (canonicalName.equals("java.util.ArrayList")) {
+            final ArrayList list = (ArrayList) o;
+            if (list.size() > 0) {
+                String componentClass = list.get(0).getClass().getCanonicalName();
+                return canonicalName + "<" + componentClass + ">";
+            }
+        }
+        return canonicalName;
     }
 
     private long readExpirationFromDisk(InputStream is) throws IOException {

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/ContributorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/ContributorsFragment.java
@@ -31,12 +31,11 @@ import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.adapter.ContributorAdapter;
 import org.gdg.frisbee.android.api.GitHub;
 import org.gdg.frisbee.android.api.model.Contributor;
+import org.gdg.frisbee.android.api.model.ContributorList;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.utils.Utils;
 import org.joda.time.DateTime;
-
-import java.util.ArrayList;
 
 import butterknife.ButterKnife;
 import de.keyboardsurfer.android.widget.crouton.Crouton;
@@ -81,7 +80,7 @@ public class ContributorsFragment extends GdgListFragment {
             App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_FRISBEE_CONTRIBUTORS, false, new ModelCache.CacheListener() {
                 @Override
                 public void onGet(Object item) {
-                    ArrayList<Contributor> contributors = (ArrayList<Contributor>) item;
+                    ContributorList contributors = (ContributorList) item;
 
                     Crouton.makeText(getActivity(), getString(R.string.cached_content), Style.INFO).show();
                     mAdapter.addAll(contributors);
@@ -101,9 +100,9 @@ public class ContributorsFragment extends GdgListFragment {
                 .setConverter(new GsonConverter(Utils.getGson(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)))
                 .build().create(GitHub.class);
         
-        gitHubClient.getContributors(Const.GITHUB_ORGA, Const.GITHUB_REPO, new Callback<ArrayList<Contributor>>() {
+        gitHubClient.getContributors(Const.GITHUB_ORGA, Const.GITHUB_REPO, new Callback<ContributorList>() {
             @Override
-            public void success(final ArrayList<Contributor> contributors, retrofit.client.Response response) {
+            public void success(final ContributorList contributors, retrofit.client.Response response) {
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_FRISBEE_CONTRIBUTORS,
                         contributors,
                         DateTime.now().plusDays(1),

--- a/app/src/main/java/org/gdg/frisbee/android/utils/Utils.java
+++ b/app/src/main/java/org/gdg/frisbee/android/utils/Utils.java
@@ -49,7 +49,6 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import timber.log.Timber;

--- a/app/src/main/java/org/gdg/frisbee/android/utils/Utils.java
+++ b/app/src/main/java/org/gdg/frisbee/android/utils/Utils.java
@@ -67,14 +67,6 @@ public class Utils {
     private Utils() {
 
     }
-    
-    public static <T> List<T> createListOfType(Class<T> type) {
-        return new ArrayList<T>();
-    }
-
-    public static <K, V> Map<K, V> createMapOfType(Class<K> keyType, Class<V> valueType) {
-        return new HashMap<K, V>();
-    }
 
     /**
      * @return Application's version code from the {@code PackageManager}.


### PR DESCRIPTION
This PR removes use of ArrayList and instead uses subclasses of ArrayList.

The ModelCache could not restore the component class of lists because the generic type information was in https://github.com/gdg-x/frisbee/blob/1cdbaa6d0c7575ad4eb79ad4762ece6faa8f46ff/app/src/main/java/org/gdg/frisbee/android/utils/Utils.java#L71 was erased.