### PR TITLE
Crotuons are now showed below Toolbar and SlidingTabs

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/activity/FirstStartActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/FirstStartActivity.java
@@ -291,7 +291,7 @@ public class FirstStartActivity extends AppCompatActivity implements
                             public void failure(RetrofitError error) {
                                 setLoadingScreen(false);
                                 Crouton.showText(FirstStartActivity.this, getString(R.string.server_error), Style.ALERT);
-                                Timber.e(error, "Fail");
+                                Timber.e(error, "GCM Register Fail");
                             }
                         });
 

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdeActivity.java
@@ -103,7 +103,8 @@ public class GdeActivity extends GdgNavDrawerActivity {
             public void failure(RetrofitError error) {
 
                 try {
-                    Crouton.makeText(GdeActivity.this, R.string.fetch_gde_failed, Style.ALERT).show();
+                    Crouton.makeText(GdeActivity.this, R.string.fetch_gde_failed,
+                            Style.ALERT, R.id.content_frame).show();
                 } catch (IllegalStateException exception) {
                 }
                 Timber.e(error, "Could'nt fetch GDE list");

--- a/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/GdgNavDrawerActivity.java
@@ -127,7 +127,8 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
                 if (PrefUtils.isSignedIn(this) && getGoogleApiClient().isConnected()) {
                     startActivityForResult(Games.Achievements.getAchievementsIntent(getGoogleApiClient()), 0);
                 } else {
-                    Crouton.makeText(GdgNavDrawerActivity.this, getString(R.string.achievements_need_signin), Style.INFO).show();
+                    Crouton.makeText(GdgNavDrawerActivity.this, R.string.achievements_need_signin,
+                            Style.INFO, R.id.content_frame).show();
                 }
                 break;
             case Const.DRAWER_HOME:
@@ -146,7 +147,8 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
                 if (PrefUtils.isSignedIn(this) && getGoogleApiClient().isConnected()) {
                     navigateTo(ArrowActivity.class, null);
                 } else {
-                    Crouton.makeText(GdgNavDrawerActivity.this, getString(R.string.arrow_need_games), Style.INFO).show();
+                    Crouton.makeText(GdgNavDrawerActivity.this, R.string.arrow_need_games,
+                            Style.INFO, R.id.content_frame).show();
                 }
                 break;
             case Const.DRAWER_SETTINGS:

--- a/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
@@ -141,7 +141,8 @@ public class MainActivity extends GdgNavDrawerActivity {
                     if (Utils.isOnline(MainActivity.this)) {
                         fetchChapters();
                     } else {
-                        Crouton.makeText(MainActivity.this, getString(R.string.offline_alert), Style.ALERT).show();
+                        Crouton.makeText(MainActivity.this, getString(R.string.offline_alert),
+                                Style.ALERT, R.id.content_frame).show();
                     }
                 }
             });
@@ -243,7 +244,8 @@ public class MainActivity extends GdgNavDrawerActivity {
 
             public void failure(RetrofitError error) {
                 try {
-                    Crouton.makeText(MainActivity.this, R.string.fetch_chapters_failed, Style.ALERT).show();
+                    Crouton.makeText(MainActivity.this, R.string.fetch_chapters_failed,
+                            Style.ALERT, R.id.content_frame).show();
                 } catch (IllegalStateException exception) {
                 }
                 Timber.e(error, "Couldn't fetch chapter list");

--- a/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/PulseActivity.java
@@ -114,7 +114,8 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
             @Override
             public void failure(RetrofitError error) {
                 try {
-                    Crouton.makeText(PulseActivity.this, R.string.fetch_chapters_failed, Style.ALERT).show();
+                    Crouton.makeText(PulseActivity.this, R.string.fetch_chapters_failed,
+                            Style.ALERT, R.id.content_frame).show();
                 } catch (IllegalStateException exception) {
                 }
                 Timber.e(error, "Couldn't fetch chapter list");

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
@@ -117,7 +117,8 @@ public class EventOverviewFragment extends Fragment {
             @Override
             public void failure(RetrofitError error) {
                 if (isAdded()) {
-                    Crouton.makeText(getActivity(), R.string.server_error, Style.ALERT).show();
+                    Crouton.makeText(getActivity(), R.string.server_error,
+                            Style.ALERT, R.id.content_frame).show();
                 }
                 Timber.d(error, "error while retrieving event %s", eventId);
             }
@@ -178,13 +179,15 @@ public class EventOverviewFragment extends Fragment {
                         @Override
                         public void failure(RetrofitError error) {
                             if (isAdded()) {
-                                Crouton.makeText(getActivity(), getString(R.string.fetch_chapters_failed), Style.ALERT).show();
+                                Crouton.makeText(getActivity(), R.string.fetch_chapters_failed,
+                                        Style.ALERT, R.id.content_frame).show();
                             }
                             Timber.e(error, "Could'nt fetch chapter list");
                         }
                     });
                 } else {
-                    Crouton.makeText(getActivity(), getString(R.string.offline_alert), Style.ALERT).show();
+                    Crouton.makeText(getActivity(), R.string.offline_alert,
+                            Style.ALERT, R.id.content_frame).show();
                 }
             }
         });

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
@@ -61,7 +61,8 @@ public abstract class EventListFragment extends GdgListFragment {
         setIsLoading(false);
         e.printStackTrace();
         if (isAdded()) {
-            Crouton.makeText(getActivity(), getString(R.string.fetch_events_failed), Style.ALERT).show();
+            Crouton.makeText(getActivity(), R.string.fetch_events_failed,
+                    Style.ALERT, R.id.content_frame).show();
         }
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
@@ -72,13 +72,15 @@ public class GdgEventListFragment extends EventListFragment {
 
                     mAdapter.addAll(events);
                     setIsLoading(false);
-                    Crouton.makeText(getActivity(), getString(R.string.cached_content), Style.INFO).show();
+                    Crouton.makeText(getActivity(), R.string.cached_content,
+                            Style.INFO, R.id.content_frame).show();
                 }
 
                 @Override
                 public void onNotFound(String key) {
                     setIsLoading(false);
-                    Crouton.makeText(getActivity(), getString(R.string.offline_alert), Style.ALERT).show();
+                    Crouton.makeText(getActivity(), R.string.offline_alert,
+                            Style.ALERT, R.id.content_frame).show();
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesActivity.java
@@ -69,7 +69,7 @@ public class TaggedEventSeriesActivity extends GdgNavDrawerActivity {
 
         FragmentTransaction trans = getSupportFragmentManager().beginTransaction();
         final String cacheExtra = getIntent().getStringExtra(Const.EXTRA_TAGGED_EVENT_CACHEKEY);
-        trans.replace(R.id.content_fragment, TaggedEventSeriesFragment.newInstance(
+        trans.replace(R.id.content_frame, TaggedEventSeriesFragment.newInstance(
                 cacheExtra != null ? cacheExtra : "specialevent",
                 mTaggedEventSeries,
                 /* addDescriptonAsHeader */ mDescription == null));

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
@@ -154,7 +154,8 @@ public class TaggedEventSeriesFragment extends EventListFragment {
                     sortEvents();
                     setIsLoading(false);
                     if (isAdded()) {
-                        Crouton.makeText(getActivity(), getString(R.string.cached_content), Style.INFO).show();
+                        Crouton.makeText(getActivity(), R.string.cached_content,
+                                Style.INFO, R.id.content_frame).show();
                     }
                 }
 
@@ -162,7 +163,8 @@ public class TaggedEventSeriesFragment extends EventListFragment {
                 public void onNotFound(String key) {
                     setIsLoading(false);
                     if (isAdded()) {
-                        Crouton.makeText(getActivity(), getString(R.string.offline_alert), Style.ALERT).show();
+                        Crouton.makeText(getActivity(), R.string.offline_alert,
+                                Style.ALERT, R.id.content_frame).show();
                     }
                 }
             });

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/ContributorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/ContributorsFragment.java
@@ -82,13 +82,15 @@ public class ContributorsFragment extends GdgListFragment {
                 public void onGet(Object item) {
                     ContributorList contributors = (ContributorList) item;
 
-                    Crouton.makeText(getActivity(), getString(R.string.cached_content), Style.INFO).show();
+                    Crouton.makeText(getActivity(), R.string.cached_content,
+                            Style.INFO, R.id.content_frame).show();
                     mAdapter.addAll(contributors);
                 }
 
                 @Override
                 public void onNotFound(String key) {
-                    Crouton.makeText(getActivity(), getString(R.string.offline_alert), Style.ALERT).show();
+                    Crouton.makeText(getActivity(), R.string.offline_alert,
+                            Style.ALERT, R.id.content_frame).show();
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/InfoFragment.java
@@ -150,7 +150,6 @@ public class InfoFragment extends Fragment {
                 @Override
                 public void onGet(Object item) {
                     final Person chachedChapter = (Person) item;
-                    Crouton.makeText(getActivity(), getString(R.string.cached_content), Style.INFO).show();
                     updateChapterUIFrom(chachedChapter);
 
                     for (int chapterIndex = 0; chapterIndex < chachedChapter.getUrls().size(); chapterIndex++) {
@@ -178,7 +177,8 @@ public class InfoFragment extends Fragment {
                                     }
                                 });
                             } catch (Exception ex) {
-                                Crouton.makeText(getActivity(), String.format(getString(R.string.bogus_organizer), org), Style.ALERT);
+                                Crouton.makeText(getActivity(), getString(R.string.bogus_organizer, org),
+                                        Style.ALERT, R.id.content_frame);
                             }
                         }
                     }
@@ -186,7 +186,8 @@ public class InfoFragment extends Fragment {
 
                 @Override
                 public void onNotFound(String key) {
-                    Crouton.makeText(getActivity(), getString(R.string.offline_alert), Style.ALERT).show();
+                    Crouton.makeText(getActivity(), R.string.offline_alert,
+                            Style.ALERT, R.id.content_frame).show();
                 }
             });
         }
@@ -250,7 +251,8 @@ public class InfoFragment extends Fragment {
                             mFetchOrganizerInfo.addParameter(organizerParameter);
                         } catch (Exception ex) {
                             if (isAdded()) {
-                                Crouton.makeText(getActivity(), String.format(getString(R.string.bogus_organizer), org), Style.ALERT);
+                                Crouton.makeText(getActivity(), getString(R.string.bogus_organizer, org),
+                                        Style.ALERT, R.id.content_frame);
                             }
                         }
                     }

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/NewsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/NewsFragment.java
@@ -149,7 +149,8 @@ public class NewsFragment extends SwipeRefreshRecyclerViewFragment
                     ActivityFeed feed = (ActivityFeed) item;
 
                     if (isAdded()) {
-                        Crouton.makeText(getActivity(), getString(R.string.cached_content), Style.INFO).show();
+                        Crouton.makeText(getActivity(), R.string.cached_content,
+                                Style.INFO, R.id.content_frame).show();
                     }
 
                     mAdapter.addAll(feed.getItems());
@@ -159,7 +160,8 @@ public class NewsFragment extends SwipeRefreshRecyclerViewFragment
                 @Override
                 public void onNotFound(String key) {
                     if (isAdded()) {
-                        Crouton.makeText(getActivity(), getString(R.string.offline_alert), Style.ALERT).show();
+                        Crouton.makeText(getActivity(), R.string.offline_alert,
+                                Style.ALERT, R.id.content_frame).show();
                     }
                 }
             });

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/PulseFragment.java
@@ -128,7 +128,8 @@ public class PulseFragment extends GdgListFragment {
                 @Override
                 public void failure(RetrofitError error) {
                     if (isAdded()) {
-                        Crouton.makeText(getActivity(), getString(R.string.fetch_chapters_failed), Style.ALERT).show();
+                        Crouton.makeText(getActivity(), R.string.fetch_chapters_failed,
+                                Style.ALERT, R.id.content_frame).show();
                     }
                     Timber.e(error, "Couldn't fetch pulse");
                 }
@@ -152,7 +153,8 @@ public class PulseFragment extends GdgListFragment {
                 @Override
                 public void failure(RetrofitError error) {
                     if (isAdded()) {
-                        Crouton.makeText(getActivity(), getString(R.string.fetch_chapters_failed), Style.ALERT).show();
+                        Crouton.makeText(getActivity(), R.string.fetch_chapters_failed,
+                                Style.ALERT, R.id.content_frame).show();
                     }
                     Timber.e(error, "Couldn't fetch pulse");
                 }

--- a/app/src/main/res/layout-land/activity_special.xml
+++ b/app/src/main/res/layout-land/activity_special.xml
@@ -34,14 +34,13 @@
     <include layout="@layout/toolbar_actionbar" />
 
     <LinearLayout
-      android:id="@+id/content_frame"
       android:baselineAligned="false"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:orientation="horizontal">
 
       <FrameLayout
-        android:id="@+id/content_fragment"
+        android:id="@+id/content_frame"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="3" />

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -30,8 +30,14 @@
     android:layout_height="wrap_content"
     android:background="@color/theme_primary" />
 
-  <android.support.v4.view.ViewPager
-    android:id="@+id/pager"
+  <FrameLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    android:id="@+id/content_frame">
+
+    <android.support.v4.view.ViewPager
+      android:id="@+id/pager"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content" />
+  </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -29,8 +29,14 @@
     android:layout_height="wrap_content"
     android:background="@color/theme_primary" />
 
-  <android.support.v4.view.ViewPager
-    android:id="@+id/pager"
+  <FrameLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    android:id="@+id/content_frame">
+
+    <android.support.v4.view.ViewPager
+      android:id="@+id/pager"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content" />
+  </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_gde.xml
+++ b/app/src/main/res/layout/activity_gde.xml
@@ -37,10 +37,16 @@
       android:layout_height="wrap_content"
       android:background="@color/theme_primary" />
 
-    <android.support.v4.view.ViewPager
-      android:id="@+id/pager"
+    <FrameLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content" />
+      android:layout_height="wrap_content"
+      android:id="@+id/content_frame">
+
+      <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    </FrameLayout>
   </LinearLayout>
 
   <include layout="@layout/navdrawer" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,6 @@
   android:orientation="vertical">
 
   <LinearLayout
-    android:id="@+id/content_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -38,10 +37,16 @@
       android:layout_height="wrap_content"
       android:background="@color/theme_primary" />
 
-    <android.support.v4.view.ViewPager
-      android:id="@+id/pager"
+    <FrameLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content" />
+      android:layout_height="wrap_content"
+      android:id="@+id/content_frame">
+
+      <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    </FrameLayout>
   </LinearLayout>
 
   <include layout="@layout/navdrawer" />

--- a/app/src/main/res/layout/activity_pulse.xml
+++ b/app/src/main/res/layout/activity_pulse.xml
@@ -37,10 +37,16 @@
       android:layout_height="wrap_content"
       android:background="@color/theme_primary" />
 
-    <android.support.v4.view.ViewPager
-      android:id="@+id/pager"
+    <FrameLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content" />
+      android:layout_height="wrap_content"
+      android:id="@+id/content_frame">
+
+      <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    </FrameLayout>
   </LinearLayout>
 
   <include layout="@layout/navdrawer" />

--- a/app/src/main/res/layout/activity_special.xml
+++ b/app/src/main/res/layout/activity_special.xml
@@ -25,7 +25,6 @@
   android:orientation="vertical">
 
   <LinearLayout
-    android:id="@+id/content_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -33,7 +32,7 @@
     <include layout="@layout/toolbar_actionbar" />
 
     <FrameLayout
-      android:id="@+id/content_fragment"
+      android:id="@+id/content_frame"
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:layout_weight="1" />


### PR DESCRIPTION
- "content_frame" id is used to show Croutons.
- This id is present in all layouts as a `FrameLayout`
- For the future, if "content_frame" is not present, Crouton library does not crash, it displays the default behavior. So there wont be any problem.

Future Work:
Change most of the Error Croutons into empty view with an error message. 

Fixes #343 