### PR TITLE
Login dialog

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/MainActivity.java
@@ -187,11 +187,12 @@ public class MainActivity extends GdgNavDrawerActivity {
     }
 
     private void updateChapterPages() {
+        final boolean wasOrganizer = App.getInstance().isOrganizer();
         App.getInstance().checkOrganizer(getGoogleApiClient(),
                 new OrganizerChecker.Callbacks() {
                     @Override
                     public void onOrganizerResponse(boolean isOrganizer) {
-                        if (mViewPagerAdapter != null) {
+                        if (mViewPagerAdapter != null && wasOrganizer != isOrganizer) {
                             mViewPagerAdapter.notifyDataSetChanged();
                         }
                     }

--- a/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
@@ -39,8 +39,10 @@ public class OrganizerChecker {
     }
 
     public void checkOrganizer(GoogleApiClient apiClient, final Callbacks responseHandler) {
-        final Person plusPerson = PrefUtils.isSignedIn(apiClient.getContext())
-                ? Plus.PeopleApi.getCurrentPerson(apiClient) : null;
+        Person plusPerson = null;
+        if (apiClient.isConnected() && PrefUtils.isSignedIn(apiClient.getContext())) {
+            plusPerson = Plus.PeopleApi.getCurrentPerson(apiClient);
+        }
         final String currentId = plusPerson != null ? plusPerson.getId() : null;
 
         if (currentId == null 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,4 +168,6 @@
     <string name="resource">Resource</string>
     <string name="cd_navdrawer_image">Navigation Drawer Chapter Image</string>
     <string name="cd_navdrawer_user_picture">User Profile Image</string>
+    <string name="title_signing_needed">Sign-in Needed</string>
+    <string name="signin">Sign-in</string>
 </resources>


### PR DESCRIPTION
Signin Needed dialog support. 
- A dialog is shown to users to take them to sign-in when needed. (It is now when Arrow and Achivements clicked)
- After a succesful login, they are also taken to the item clicked.

Fixes #222 

**Side note:** Cannot login with debug builds. I've tested it with release builds and was working. 
But after openning Arrow page, it couldn't detect that I am an organizer. It was because of a 400 error from googleapis.com. Production work fine. 