### PR TITLE
Add message for G+ community for leads

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -77,6 +77,7 @@ public class Const {
     public static final String URL_HELP = "https://support.google.com/developergroups";
     public static final String URL_GDG_RESOURCE_FOLDER = "https://drive.google.com/drive/#folders/0B55wxScz_BJtWW9aUnk2LUlNdEk";
     public static final String URL_GDG_WISDOM_BOOK = "http://gdg-wisdom.gitbooks.io/gdg-wisdom-2015/content/";
+    public static final String URL_GDG_LEADS_GPLUS_COMMUNITY = "https://plus.google.com/communities/101119632372181012379";
     public static final String EVENTS = "events";
 
     //Keys

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/LeadFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/LeadFragment.java
@@ -51,6 +51,8 @@ public class LeadFragment extends ListFragment {
         mAdapter.add(LeadMessage.newResource(getString(R.string.leads_wisdom_title),
                 getString(R.string.leads_wisdom),
                 Const.URL_GDG_WISDOM_BOOK));
+        mAdapter.add(LeadMessage.newResource(getString(R.string.leads_gplus_community_title), getString(R.string.leads_gplus_community),
+                Const.URL_GDG_LEADS_GPLUS_COMMUNITY));
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,4 +170,6 @@
     <string name="cd_navdrawer_user_picture">User Profile Image</string>
     <string name="title_signing_needed">Sign-in Needed</string>
     <string name="signin">Sign-in</string>
+    <string name="leads_gplus_community_title">G+ Community for Chapter Leads</string>
+    <string name="leads_gplus_community">This G+ community is about sharing experiences and knowledge about running a GDG chapter. Join and contribute!</string>
 </resources>


### PR DESCRIPTION
This PR adds another message for chapter leads, it is about the g+ community:

![device-2015-07-22-151905](https://cloud.githubusercontent.com/assets/1449049/8826227/48a94b44-3085-11e5-8d27-d4cf1b28d105.png)
