### PR TITLE
Fix/Transform bitmap only when configuration available

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/view/BitmapBorderTransformation.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/BitmapBorderTransformation.java
@@ -23,6 +23,10 @@ public class BitmapBorderTransformation implements Transformation {
 
     @Override
     public Bitmap transform(Bitmap source) {
+        if (source.getConfig() == null) {
+            return source;
+        }
+
         int width = source.getWidth();
         int height = source.getHeight();
 


### PR DESCRIPTION
This PR adds a check for bitmaps without configuration. This is needed for bitmap transformations.

Fixes #368.
 