### PR TITLE
Organiser Check is fixed

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -61,9 +61,6 @@ public class Const {
 
     //Arrow
     public static final String QR_MSG_PREFIX = "gdgx://arrow?m=";
-    public static final String PREF_ORGANIZER_CHECK_TIME = "pref_organizer_check_time";
-    public static final String PREF_ORGANIZER_CHECK_ID = "pref_organizer_check_id";
-    public static final long ORGANIZER_CHECK_MAX_TIME = 2592000000L; // 30 days
     public static final String ARROW_MIME = "application/vnd.org.gdgx.frisbee.arrow";
     public static final String ARROW_LB = "CgkIh5yNxL8MEAIQBw";
     public static final String ARROW_K = "XXXX111122223333";

--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -61,6 +61,10 @@ public class Const {
 
     //Arrow
     public static final String QR_MSG_PREFIX = "gdgx://arrow?m=";
+    public static final String PREF_ORGANIZER_CHECK_TIME = "pref_organizer_check_time";
+    public static final String PREF_ORGANIZER_CHECK_ID = "pref_organizer_check_id";
+    public static final String PREF_ORGANIZER_STATE = "pref_organizer_state";
+    public static final long ORGANIZER_CHECK_MAX_TIME = 2592000000L; // 30 days
     public static final String ARROW_MIME = "application/vnd.org.gdgx.frisbee.arrow";
     public static final String ARROW_LB = "CgkIh5yNxL8MEAIQBw";
     public static final String ARROW_K = "XXXX111122223333";

--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -16,6 +16,8 @@
 
 package org.gdg.frisbee.android;
 
+import android.text.format.DateUtils;
+
 import org.joda.time.DateTime;
 
 /**
@@ -64,7 +66,7 @@ public class Const {
     public static final String PREF_ORGANIZER_CHECK_TIME = "pref_organizer_check_time";
     public static final String PREF_ORGANIZER_CHECK_ID = "pref_organizer_check_id";
     public static final String PREF_ORGANIZER_STATE = "pref_organizer_state";
-    public static final long ORGANIZER_CHECK_MAX_TIME = 2592000000L; // 30 days
+    public static final long ORGANIZER_CHECK_MAX_TIME = DateUtils.WEEK_IN_MILLIS;
     public static final String ARROW_MIME = "application/vnd.org.gdgx.frisbee.arrow";
     public static final String ARROW_LB = "CgkIh5yNxL8MEAIQBw";
     public static final String ARROW_K = "XXXX111122223333";

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -138,7 +138,7 @@ public class App extends Application implements LocationListener {
 
         refWatcher = LeakCanary.install(this);
 
-        mOrganizerChecker = new OrganizerChecker();
+        mOrganizerChecker = new OrganizerChecker(PrefUtils.prefs(this));
 
         GoogleAnalytics.getInstance(this).setAppOptOut(PrefUtils.isAnalyticsEnabled(this));
 

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -138,7 +138,7 @@ public class App extends Application implements LocationListener {
 
         refWatcher = LeakCanary.install(this);
 
-        mOrganizerChecker = new OrganizerChecker(PrefUtils.prefs(this));
+        mOrganizerChecker = new OrganizerChecker();
 
         GoogleAnalytics.getInstance(this).setAppOptOut(PrefUtils.isAnalyticsEnabled(this));
 

--- a/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
@@ -1,12 +1,9 @@
 package org.gdg.frisbee.android.app;
 
-import android.content.SharedPreferences;
-
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.plus.Plus;
 import com.google.android.gms.plus.model.people.Person;
 
-import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.api.model.OrganizerCheckResponse;
 import org.gdg.frisbee.android.utils.PrefUtils;
 
@@ -15,23 +12,8 @@ import retrofit.RetrofitError;
 
 public class OrganizerChecker {
     private boolean mIsOrganizer = false;
-    private long mLastOrganizerCheck = 0;
-    private String mCheckedId = null;
-    private SharedPreferences mPreferences;
 
-    public OrganizerChecker(SharedPreferences preferences) {
-        mPreferences = preferences;
-
-        mLastOrganizerCheck = mPreferences.getLong(Const.PREF_ORGANIZER_CHECK_TIME, 0);
-        mCheckedId = mPreferences.getString(Const.PREF_ORGANIZER_CHECK_ID, null);
-    }
-
-    public long getLastOrganizerCheckTime() {
-        return mLastOrganizerCheck;
-    }
-
-    public String getLastOrganizerCheckId() {
-        return mCheckedId;
+    public OrganizerChecker() {
     }
 
     public boolean isOrganizer() {
@@ -45,16 +27,11 @@ public class OrganizerChecker {
         }
         final String currentId = plusPerson != null ? plusPerson.getId() : null;
 
-        if (currentId == null 
-                || !currentId.equals(mCheckedId)  
-                || System.currentTimeMillis() > mLastOrganizerCheck + Const.ORGANIZER_CHECK_MAX_TIME) {
+        if (currentId != null) {
             mIsOrganizer = false;
             App.getInstance().getGdgXHub().checkOrganizer(currentId, new Callback<OrganizerCheckResponse>() {
                 @Override
                 public void success(OrganizerCheckResponse organizerCheckResponse, retrofit.client.Response response) {
-                    mLastOrganizerCheck = System.currentTimeMillis();
-                    mCheckedId = currentId;
-                    savePreferences();
 
                     if (organizerCheckResponse.getChapters().size() > 0) {
                         mIsOrganizer = true;
@@ -74,13 +51,6 @@ public class OrganizerChecker {
         } else {
             responseHandler.onOrganizerResponse(mIsOrganizer);
         }
-    }
-
-    private void savePreferences() {
-        SharedPreferences.Editor editor = mPreferences.edit();
-        editor.putLong(Const.PREF_ORGANIZER_CHECK_TIME, getLastOrganizerCheckTime());
-        editor.putString(Const.PREF_ORGANIZER_CHECK_ID, getLastOrganizerCheckId());
-        editor.apply();
     }
 
     public interface Callbacks {

--- a/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
@@ -1,9 +1,12 @@
 package org.gdg.frisbee.android.app;
 
+import android.content.SharedPreferences;
+
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.plus.Plus;
 import com.google.android.gms.plus.model.people.Person;
 
+import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.api.model.OrganizerCheckResponse;
 import org.gdg.frisbee.android.utils.PrefUtils;
 
@@ -12,8 +15,24 @@ import retrofit.RetrofitError;
 
 public class OrganizerChecker {
     private boolean mIsOrganizer = false;
+    private long mLastOrganizerCheck = 0;
+    private String mCheckedId = null;
+    private SharedPreferences mPreferences;
 
-    public OrganizerChecker() {
+    public OrganizerChecker(SharedPreferences preferences) {
+        mPreferences = preferences;
+
+        mLastOrganizerCheck = mPreferences.getLong(Const.PREF_ORGANIZER_CHECK_TIME, 0);
+        mCheckedId = mPreferences.getString(Const.PREF_ORGANIZER_CHECK_ID, null);
+        mIsOrganizer = mPreferences.getBoolean(Const.PREF_ORGANIZER_STATE, false);
+    }
+
+    public long getLastOrganizerCheckTime() {
+        return mLastOrganizerCheck;
+    }
+
+    public String getLastOrganizerCheckId() {
+        return mCheckedId;
     }
 
     public boolean isOrganizer() {
@@ -27,19 +46,19 @@ public class OrganizerChecker {
         }
         final String currentId = plusPerson != null ? plusPerson.getId() : null;
 
-        if (currentId != null) {
+        if (currentId != null
+                && (!currentId.equals(mCheckedId)
+                || System.currentTimeMillis() > mLastOrganizerCheck + Const.ORGANIZER_CHECK_MAX_TIME)) {
             mIsOrganizer = false;
             App.getInstance().getGdgXHub().checkOrganizer(currentId, new Callback<OrganizerCheckResponse>() {
                 @Override
                 public void success(OrganizerCheckResponse organizerCheckResponse, retrofit.client.Response response) {
+                    mLastOrganizerCheck = System.currentTimeMillis();
+                    mCheckedId = currentId;
+                    mIsOrganizer = organizerCheckResponse.getChapters().size() > 0;
+                    responseHandler.onOrganizerResponse(mIsOrganizer);
 
-                    if (organizerCheckResponse.getChapters().size() > 0) {
-                        mIsOrganizer = true;
-                        responseHandler.onOrganizerResponse(true);
-                    } else {
-                        mIsOrganizer = false;
-                        responseHandler.onOrganizerResponse(false);
-                    }
+                    savePreferences();
                 }
 
                 @Override
@@ -53,8 +72,17 @@ public class OrganizerChecker {
         }
     }
 
+    private void savePreferences() {
+        mPreferences.edit()
+                .putLong(Const.PREF_ORGANIZER_CHECK_TIME, getLastOrganizerCheckTime())
+                .putString(Const.PREF_ORGANIZER_CHECK_ID, getLastOrganizerCheckId())
+                .putBoolean(Const.PREF_ORGANIZER_STATE, isOrganizer())
+                .apply();
+    }
+
     public interface Callbacks {
         void onOrganizerResponse(boolean isOrganizer);
+
         void onErrorResponse();
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
+++ b/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
@@ -473,6 +473,17 @@ public class ModelCache {
         }
     }
 
+    public void removeAsync(final String url) {
+        new AsyncTask<Void, Void, Void>() {
+
+            @Override
+            protected Void doInBackground(Void... voids) {
+                ModelCache.this.remove(url);
+                return null;
+            }
+        }.execute();
+    }
+
     synchronized void setDiskCache(DiskLruCache diskCache) {
         mDiskCache = diskCache;
 

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
@@ -6,6 +6,7 @@ import android.support.design.widget.Snackbar;
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.api.model.Event;
+import org.gdg.frisbee.android.api.model.SimpleEvent;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.utils.Utils;
@@ -67,13 +68,18 @@ public class GdgEventListFragment extends EventListFragment {
             App.getInstance().getModelCache().getAsync(cacheKey, false, new ModelCache.CacheListener() {
                 @Override
                 public void onGet(Object item) {
-                    ArrayList<Event> events = (ArrayList<Event>) item;
 
-                    mAdapter.addAll(events);
-                    setIsLoading(false);
-                    Snackbar snackbar = Snackbar.make(getView(), R.string.cached_content,
-                            Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.info(snackbar).show();
+                    if (checkValidCache(item)) {
+                        ArrayList<Event> events = (ArrayList<Event>) item;
+
+                        mAdapter.addAll(events);
+                        setIsLoading(false);
+                        Snackbar snackbar = Snackbar.make(getView(), R.string.cached_content,
+                                Snackbar.LENGTH_SHORT);
+                        ColoredSnackBar.info(snackbar).show();
+                    } else {
+                        App.getInstance().getModelCache().removeAsync(cacheKey);
+                    }
                 }
 
                 @Override
@@ -85,5 +91,15 @@ public class GdgEventListFragment extends EventListFragment {
                 }
             });
         }
+    }
+
+    private boolean checkValidCache(Object item) {
+        if (item instanceof ArrayList) {
+            ArrayList<?> result = (ArrayList) item;
+            if (result.size() > 0) {
+                return result.get(0) instanceof SimpleEvent;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
- It was caching for 30 days in SharedPrefs. Cache mechanism is completely removed. I can re-add it if someone wants. I don't think it is necessary. New organisers should see them immediately.
- When the currentId is null, which happens on app start, it was making the request. Since the request fails, it thoughts that the user is not organiser.

Fixes #360