### PR TITLE
Remove browser api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ gem install image_optim image_optim_pack
 The file looks like:
 ```
 android_simple_api_access_key=
+ip_simple_api_access_key=
 android_backup_key=
 play_app_id=
 gcm_sender_id=
 hub_client_id=
 ```
 
-The first one (`android_simple_api_access_key`) is a regular API access key which can be gotten by creating a new project at [Google Developer Console](https://console.developers.google.com/project). `android_backup_key` is not necessary but can be obtained at this [page](http://developer.android.com/google/backup/signup.html). `play_app_id` is the Google Developer Console project id and lastly `hub_client_id` is the client id used for oAuth with Google.
+The first 2 (`android_simple_api_access_key` and `ip_simple_api_access_key`) are regular regular API access keys which can be obtained by creating a new project at [Google Developer Console](https://console.developers.google.com/project). `android_backup_key` is not necessary but can be obtained at this [page](http://developer.android.com/google/backup/signup.html). `play_app_id` is the Google Developer Console project id and lastly `hub_client_id` is the client id used for oAuth with Google.
 
 
 ###Contributors

--- a/README.md
+++ b/README.md
@@ -54,15 +54,13 @@ gem install image_optim image_optim_pack
 The file looks like:
 ```
 android_simple_api_access_key=
-browser_simple_api_access_key=
-ip_simple_api_access_key=
 android_backup_key=
 play_app_id=
 gcm_sender_id=
 hub_client_id=
 ```
 
-The first 3 (`android_simple_api_access_key`, `browser_simple_api_access_key`, `ip_simple_api_access_key`) are regular API access keys which can be gotten by creating a new project at [Google Developer Console](https://console.developers.google.com/project). `android_backup_key` is not necessary but can be obtained at this [page](http://developer.android.com/google/backup/signup.html). `play_app_id` is the Google Developer Console project id and lastly `hub_client_id` is the client id used for oAuth with Google.
+The first one (`android_simple_api_access_key`) is a regular API access key which can be gotten by creating a new project at [Google Developer Console](https://console.developers.google.com/project). `android_backup_key` is not necessary but can be obtained at this [page](http://developer.android.com/google/backup/signup.html). `play_app_id` is the Google Developer Console project id and lastly `hub_client_id` is the client id used for oAuth with Google.
 
 
 ###Contributors

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ def versionPatch = 0
 def versionBuild = 1 // bump for dogfood builds, public betas, etc.
 
 def supportVersion = "22.2.1"
-def playServicesVersion = "7.3.0"
+def playServicesVersion = "7.5.0"
 
 android {
     compileSdkVersion 22
@@ -40,6 +40,7 @@ android {
     }
 
     defaultConfig {
+        applicationId "org.gdg.frisbee.android"
         minSdkVersion 16
         targetSdkVersion 22
         versionCode versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,6 +152,10 @@ play {
     track = 'alpha'
 }
 
+configurations {
+    compile.exclude module: 'httpclient'
+}
+
 dependencies {
     //Android Support
     compile "com.android.support:support-v4:$supportVersion"
@@ -172,7 +176,6 @@ dependencies {
     compile "com.google.android.gms:play-services-gcm:$playServicesVersion"
 
     //Google
-    compile 'com.google.code.gson:gson:2.3.1'
     compile 'com.google.http-client:google-http-client-gson:1.20.0'
     compile 'com.google.apis:google-api-services-plus:v1-rev126-1.18.0-rc'
     compile 'com.google.android.apps.dashclock:dashclock-api:2.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,7 @@ android {
         
         //KEYS
         buildConfigField "String", "ANDROID_SIMPLE_API_ACCESS_KEY", "\"" + (local_properties.android_simple_api_access_key ?: "") + "\""
+        buildConfigField "String", "IP_SIMPLE_API_ACCESS_KEY", "\"" + (local_properties.ip_simple_api_access_key ?: "") + "\""
         buildConfigField "String", "HUB_CLIENT_ID", "\"" + (local_properties.hub_client_id ?: "") + "\""
         buildConfigField "String", "PLAY_APP_ID", "\"" + (local_properties.play_app_id ?: "") + "\""
         buildConfigField "String", "GCM_SENDER_ID", "\"" + (local_properties.gcm_sender_id ?: "") + "\""

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,8 +57,6 @@ android {
         
         //KEYS
         buildConfigField "String", "ANDROID_SIMPLE_API_ACCESS_KEY", "\"" + (local_properties.android_simple_api_access_key ?: "") + "\""
-        buildConfigField "String", "BROWSER_SIMPLE_API_ACCESS_KEY", "\"" + (local_properties.browser_simple_api_access_key ?: "") + "\""
-        buildConfigField "String", "IP_SIMPLE_API_ACCESS_KEY", "\"" + (local_properties.ip_simple_api_access_key ?: "") + "\""
         buildConfigField "String", "HUB_CLIENT_ID", "\"" + (local_properties.hub_client_id ?: "") + "\""
         buildConfigField "String", "PLAY_APP_ID", "\"" + (local_properties.play_app_id ?: "") + "\""
         buildConfigField "String", "GCM_SENDER_ID", "\"" + (local_properties.gcm_sender_id ?: "") + "\""

--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -78,7 +78,6 @@ public class Const {
     public static final String URL_GDG_RESOURCE_FOLDER = "https://drive.google.com/drive/#folders/0B55wxScz_BJtWW9aUnk2LUlNdEk";
     public static final String URL_GDG_WISDOM_BOOK = "http://gdg-wisdom.gitbooks.io/gdg-wisdom-2015/content/";
     public static final String URL_GDG_LEADS_GPLUS_COMMUNITY = "https://plus.google.com/communities/101119632372181012379";
-    public static final String EVENTS = "events";
 
     //Keys
     public static final String EXTRA_CHAPTER_ID = "org.gdg.frisbee.CHAPTER";

--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -89,7 +89,6 @@ public class Const {
     public static final String CACHE_KEY_PERSON = "person_";
     public static final String CACHE_KEY_NEWS = "news_";
     public static final String CACHE_KEY_PULSE = "pulse_";
-    public static final String CACHE_KEY_GDE = "gde_";
 
     public static final String GOOGLE_DEVELOPERS_YT_ID = "UC_x5XG1OV2P6uZZ5FSM9Ttw";
     public static final String ANDROID_DEVELOPERS_YT_ID = "UCVHFbqXqoYvEWM1Ddxl0QDg";

--- a/app/src/main/java/org/gdg/frisbee/android/api/model/OrganizerCheckResponse.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/model/OrganizerCheckResponse.java
@@ -14,7 +14,7 @@ public class OrganizerCheckResponse {
     private ArrayList<Chapter> chapters;
 
     public OrganizerCheckResponse() {
-        chapters = new ArrayList<Chapter>();
+        chapters = new ArrayList<>();
     }
 
     public String getUser() {

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -33,14 +33,14 @@ import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
-import com.google.api.services.plus.model.Person;
+import com.google.android.gms.plus.model.people.Person;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
-import org.gdg.frisbee.android.common.GdgNavDrawerActivity;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.common.BaseFragment;
+import org.gdg.frisbee.android.common.GdgNavDrawerActivity;
 import org.gdg.frisbee.android.task.Builder;
 import org.gdg.frisbee.android.task.CommonAsyncTask;
 import org.gdg.frisbee.android.utils.Utils;
@@ -89,7 +89,7 @@ public class InfoFragment extends BaseFragment {
                     for (int i = 0; i < params.length; i++) {
                         Timber.d("Get Organizer " + params[i]);
                         if (isAdded()) {
-                            people[i] = ((GdgNavDrawerActivity) getActivity()).getPerson(params[i]);
+                            people[i] = GdgNavDrawerActivity.getPersonSync(((GdgNavDrawerActivity) getActivity()).getGoogleApiClient(), params[0]);
                         } else {
                             // fragment is not used anymore
                             people[i] = null;
@@ -127,7 +127,7 @@ public class InfoFragment extends BaseFragment {
                         @Override
                         public Person doInBackground(String... params) {
                             if (isAdded()) {
-                                return ((GdgNavDrawerActivity) getActivity()).getPerson(params[0]);
+                                return GdgNavDrawerActivity.getPersonSync(((GdgNavDrawerActivity) getActivity()).getGoogleApiClient(), params[0]);
                             } else {
                                 // fragment is not used anymore
                                 return null;
@@ -267,7 +267,7 @@ public class InfoFragment extends BaseFragment {
                     }
                 } else {
                     TextView tv = (TextView) mInflater.inflate(R.layout.list_resource_item, (ViewGroup) getView(), false);
-                    tv.setText(Html.fromHtml("<a href='" + url.getValue() + "'>" + url.get("label") + "</a>"));
+                    tv.setText(Html.fromHtml("<a href='" + url.getValue() + "'>" + url.getLabel() + "</a>"));
                     mResourcesBox.addView(tv);
                 }
 

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -89,7 +89,7 @@ public class InfoFragment extends BaseFragment {
                     for (int i = 0; i < params.length; i++) {
                         Timber.d("Get Organizer " + params[i]);
                         if (isAdded()) {
-                            people[i] = GdgNavDrawerActivity.getPersonSync(((GdgNavDrawerActivity) getActivity()).getGoogleApiClient(), params[0]);
+                            people[i] = GdgNavDrawerActivity.getPersonSync(((GdgNavDrawerActivity) getActivity()).getGoogleApiClient(), params[i]);
                         } else {
                             // fragment is not used anymore
                             people[i] = null;
@@ -120,14 +120,14 @@ public class InfoFragment extends BaseFragment {
 
         mInflater = LayoutInflater.from(getActivity());
 
+        final String chapterPlusId = getArguments().getString(Const.EXTRA_PLUS_ID);
         if (Utils.isOnline(getActivity())) {
             new Builder<>(String.class, Person.class)
-                    .addParameter(getArguments().getString(Const.EXTRA_PLUS_ID))
                     .setOnBackgroundExecuteListener(new CommonAsyncTask.OnBackgroundExecuteListener<String, Person>() {
                         @Override
                         public Person doInBackground(String... params) {
                             if (isAdded()) {
-                                return GdgNavDrawerActivity.getPersonSync(((GdgNavDrawerActivity) getActivity()).getGoogleApiClient(), params[0]);
+                                return GdgNavDrawerActivity.getPersonSync(((GdgNavDrawerActivity) getActivity()).getGoogleApiClient(), chapterPlusId);
                             } else {
                                 // fragment is not used anymore
                                 return null;
@@ -145,8 +145,7 @@ public class InfoFragment extends BaseFragment {
                     })
                     .buildAndExecute();
         } else {
-            final String plusId = getArguments().getString(Const.EXTRA_PLUS_ID);
-            App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_PERSON + plusId, false, new ModelCache.CacheListener() {
+            App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_PERSON + chapterPlusId, false, new ModelCache.CacheListener() {
                 @Override
                 public void onGet(Object item) {
                     final Person chachedChapter = (Person) item;

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/NewsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/NewsFragment.java
@@ -82,7 +82,7 @@ public class NewsFragment extends SwipeRefreshRecyclerViewFragment
 
         mClient = new Plus.Builder(mTransport, mJsonFactory, null)
                 .setGoogleClientRequestInitializer(
-                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.IP_SIMPLE_API_ACCESS_KEY))
+                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.ANDROID_SIMPLE_API_ACCESS_KEY))
                 .build();
 
         StaggeredGridLayoutManager layoutManager = 

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/NewsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/NewsFragment.java
@@ -82,7 +82,7 @@ public class NewsFragment extends SwipeRefreshRecyclerViewFragment
 
         mClient = new Plus.Builder(mTransport, mJsonFactory, null)
                 .setGoogleClientRequestInitializer(
-                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.ANDROID_SIMPLE_API_ACCESS_KEY))
+                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.IP_SIMPLE_API_ACCESS_KEY))
                 .build();
 
         StaggeredGridLayoutManager layoutManager = 

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -74,7 +74,6 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     @InjectView(R.id.nav_view)
     NavigationView mNavigationView;
 
-    private Plus plusClient;
     private MenuItem drawerItemToNavigateAfterSignIn = null;
     private static final int GROUP_ID = 1;
 

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -373,9 +373,13 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     public static Person getPersonSync(final GoogleApiClient apiClient, final String gplusId) {
         final String cacheUrl = Const.CACHE_KEY_PERSON + gplusId;
         Object cachedPerson = App.getInstance().getModelCache().get(cacheUrl);
+        Person person = null;
 
         if (cachedPerson instanceof Person) {
-            return (Person) cachedPerson;
+            person = (Person) cachedPerson;
+            if (person.getId() != null) {
+                return person;
+            }
         }
         if (cachedPerson != null) {
             App.getInstance().getModelCache().remove(cacheUrl);
@@ -386,14 +390,13 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
             PersonBuffer personBuffer = result.getPersonBuffer();
             try {
                 if (personBuffer.getCount() > 0) {
-                    Person person = personBuffer.get(0);
+                    person = personBuffer.get(0);
                     App.getInstance().getModelCache().put(cacheUrl, person, DateTime.now().plusDays(2));
-                    return person;
                 }
             } finally {
                 personBuffer.close();
             }
         }
-        return null;
+        return person;
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -261,7 +261,7 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         super.onCreate(savedInstanceState);
         plusClient = new Plus.Builder(mTransport, mJsonFactory, null)
                 .setGoogleClientRequestInitializer(
-                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.IP_SIMPLE_API_ACCESS_KEY))
+                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.ANDROID_SIMPLE_API_ACCESS_KEY))
                 .setApplicationName("GDG Frisbee")
                 .build();
     }

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -252,16 +252,6 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-//        plusClient = new Plus.Builder(mTransport, mJsonFactory, null)
-//                .setGoogleClientRequestInitializer(
-//                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.ANDROID_SIMPLE_API_ACCESS_KEY))
-//                .setApplicationName("GDG Frisbee")
-//                .build();
-    }
-
-    @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         // Sync the toggle state after onRestoreInstanceState has occurred.

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
@@ -31,11 +31,9 @@ import android.widget.ListView;
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.api.model.SimpleEvent;
-import org.gdg.frisbee.android.event.EventActivity;
 import org.gdg.frisbee.android.common.GdgListFragment;
+import org.gdg.frisbee.android.event.EventActivity;
 import org.gdg.frisbee.android.view.ColoredSnackBar;
-import org.joda.time.DateTime;
-import org.joda.time.MutableDateTime;
 
 import java.util.ArrayList;
 
@@ -150,22 +148,6 @@ public abstract class EventListFragment extends GdgListFragment {
         }
 
         startActivity(intent);
-    }
-
-    private DateTime getMonthStart(int month) {
-        MutableDateTime date = new MutableDateTime();
-        date.setDayOfMonth(1);
-        date.setMillisOfDay(0);
-        date.setMonthOfYear(month);
-        return date.toDateTime();
-    }
-
-    private DateTime getMonthEnd(int month) {
-        MutableDateTime date = MutableDateTime.now();
-        date.setMillisOfDay(0);
-        date.setMonthOfYear(month);
-
-        return date.toDateTime().dayOfMonth().withMaximumValue().millisOfDay().withMaximumValue();
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -305,15 +305,4 @@ public class SettingsFragment extends PreferenceFragment {
             }
         }.execute();
     }
-
-    // TODO: Re-Implement with GMS 4.3
-    public void onSignInFailed() {
-        Timber.d("onSignInFailed");
-        PrefUtils.setLoggedOut(getActivity());
-        CheckBoxPreference prefGoogleSignIn = (CheckBoxPreference) findPreference(PrefUtils.SETTINGS_SIGNED_IN);
-        if (prefGoogleSignIn != null) {
-            prefGoogleSignIn.setChecked(false);
-        }
-    }
-
 }

--- a/app/src/main/java/org/gdg/frisbee/android/gde/GdeAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/gde/GdeAdapter.java
@@ -60,7 +60,7 @@ class GdeAdapter extends BaseAdapter {
 
         mClient = new Plus.Builder(mTransport, mJsonFactory, null)
                 .setGoogleClientRequestInitializer(
-                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.IP_SIMPLE_API_ACCESS_KEY))
+                        new CommonGoogleJsonClientRequestInitializer(BuildConfig.ANDROID_SIMPLE_API_ACCESS_KEY))
                 .setApplicationName("GDG Frisbee")
                 .build();
         mPlusPattern = Pattern.compile("http[s]?:\\/\\/plus\\..*google\\.com.*(\\+[a-zA-Z] +|[0-9]{21}).*");

--- a/app/src/main/java/org/gdg/frisbee/android/gde/GdeAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/gde/GdeAdapter.java
@@ -125,7 +125,10 @@ class GdeAdapter extends BaseAdapter {
                 .setOnPostExecuteListener(new CommonAsyncTask.OnPostExecuteListener<ViewHolder, Person>() {
                     @Override
                     public void onPostExecute(ViewHolder[] p, Person person) {
-                        if (person != null && p[0].thumbnailView.equals(holder.thumbnailView)) {
+                        if (person != null
+                                && person.getImage() != null
+                                && person.getImage().getUrl() != null
+                                && p[0].thumbnailView.equals(holder.thumbnailView)) {
                             Picasso.with(mContext)
                                     .load(person.getImage().getUrl().replace("sz=50", "sz=196"))
                                     .into(p[0].thumbnailView);


### PR DESCRIPTION
This work began with removing `browser_simple_api_access_key` and it included bunch of stuff. 

- `browser_simple_api_access_key` is removed. 
- `ip_simple_api_access_key` cannot be removed because G+ apis used in `NewsFragment` didn't work with `android_simple_api_access_key`
- Plus APIs used in the app are updated to be used from GMS. Only News Feed requests are done with the Google API Client. I wish we could remove it. 
- And finally got rid of the compiler warning by adding global exclude into configurations. 