### PR TITLE
fix: Listview divider in leads tab

### DIFF
--- a/app/src/main/res/layout/fragment_for_leads.xml
+++ b/app/src/main/res/layout/fragment_for_leads.xml
@@ -30,7 +30,8 @@
     android:paddingRight="@dimen/keyline_1_minus_12dp"
     android:clipToPadding="false"
     android:scrollbarStyle="outsideOverlay"
-    android:drawSelectorOnTop="true" />
+    android:drawSelectorOnTop="true"
+    android:divider="@null" />
 
   <include layout="@layout/loading_animated_view" />
 


### PR DESCRIPTION
Listview divider was visible :)

![screenshot_2015-07-25-23-28-58](https://cloud.githubusercontent.com/assets/888080/8890653/247d8ade-3326-11e5-9d92-90269e9077df.png)
