### PR TITLE
336/Add separator in NavigationView

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -76,6 +76,7 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
 
     private MenuItem drawerItemToNavigateAfterSignIn = null;
     private static final int GROUP_ID = 1;
+    private static final int SETTINGS_GROUP_ID = 2;
 
     @Override
     public void setContentView(int layoutResId) {
@@ -134,11 +135,10 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         menu.add(GROUP_ID, Const.DRAWER_ACHIEVEMENTS, Menu.NONE, R.string.achievements).setIcon(R.drawable.ic_drawer_achievements);
         menu.add(GROUP_ID, Const.DRAWER_ARROW, Menu.NONE, R.string.arrow).setIcon(R.drawable.ic_drawer_arrow);
 
-        menu.addSubMenu("");
-        menu.add(GROUP_ID, Const.DRAWER_SETTINGS, Menu.NONE, R.string.settings).setIcon(R.drawable.ic_drawer_settings);
-        menu.add(GROUP_ID, Const.DRAWER_HELP, Menu.NONE, R.string.help).setIcon(R.drawable.ic_drawer_help);
-        menu.add(GROUP_ID, Const.DRAWER_FEEDBACK, Menu.NONE, R.string.feedback).setIcon(R.drawable.ic_drawer_feedback);
-        menu.add(GROUP_ID, Const.DRAWER_ABOUT, Menu.NONE, R.string.about).setIcon(R.drawable.ic_drawer_about);
+        menu.add(SETTINGS_GROUP_ID, Const.DRAWER_SETTINGS, Menu.NONE, R.string.settings).setIcon(R.drawable.ic_drawer_settings);
+        menu.add(SETTINGS_GROUP_ID, Const.DRAWER_HELP, Menu.NONE, R.string.help).setIcon(R.drawable.ic_drawer_help);
+        menu.add(SETTINGS_GROUP_ID, Const.DRAWER_FEEDBACK, Menu.NONE, R.string.feedback).setIcon(R.drawable.ic_drawer_feedback);
+        menu.add(SETTINGS_GROUP_ID, Const.DRAWER_ABOUT, Menu.NONE, R.string.about).setIcon(R.drawable.ic_drawer_about);
 
         navigationView.setNavigationItemSelectedListener(
 


### PR DESCRIPTION
Adds a separator after Arrow menu entry.

Having more separator, e.g. for events is too much especially, if there is only one or two events.

Before | After
---|---
![device-2015-07-26-105724](https://cloud.githubusercontent.com/assets/1449049/8893163/2ebbf922-3385-11e5-91c6-b83c3d634ea6.png)|![device-2015-07-26-105350](https://cloud.githubusercontent.com/assets/1449049/8893162/2ebb2cc2-3385-11e5-97f6-8fa397583b2e.png)