### PR TITLE
Pulse page quick redesign

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/activity/ParseDeepLinkActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/activity/ParseDeepLinkActivity.java
@@ -20,7 +20,7 @@ public class ParseDeepLinkActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        String deepLinkId = PlusShare.getDeepLinkId(this.getIntent());
+        String deepLinkId = PlusShare.getDeepLinkId(getIntent());
         Intent target = parseDeepLinkId(deepLinkId);
         if (target != null) {
             startActivity(target);
@@ -37,6 +37,9 @@ public class ParseDeepLinkActivity extends Activity {
      * @return The intent corresponding to the deep-link ID.
      */
     private Intent parseDeepLinkId(String deepLinkId) {
+        if (deepLinkId == null) {
+            return null;
+        }
         Intent route = new Intent();
         Timber.d("Deep Link id: " + deepLinkId);
         String[] parts = deepLinkId.split("/");

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -64,7 +64,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     FrameLayout mContentLayout;
 
     private ArrayAdapter<String> mSpinnerAdapter;
-    private MyAdapter mViewPagerAdapter;
+    private PulsePagerAdapter mViewPagerAdapter;
     private ArrayList<String> mPulseTargets;
     private Spinner mSpinner;
 
@@ -76,8 +76,9 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
 
         mPulseTargets = new ArrayList<>();
 
-        mViewPagerAdapter = new MyAdapter(this, getSupportFragmentManager());
+        mViewPagerAdapter = new PulsePagerAdapter(this, getSupportFragmentManager());
         mSpinnerAdapter = new ArrayAdapter<String>(this, R.layout.spinner_item_actionbar);
+        mSpinnerAdapter.setDropDownViewResource(R.layout.support_simple_spinner_dropdown_item);
 
         App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_PULSE_GLOBAL, true, new ModelCache.CacheListener() {
             @Override
@@ -189,11 +190,11 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
         mSpinner.setSelection(getPulseTargets().indexOf(key));
     }
 
-    public class MyAdapter extends FragmentStatePagerAdapter {
+    public class PulsePagerAdapter extends FragmentStatePagerAdapter {
         private Context mContext;
         private String mSelectedPulseTarget;
 
-        public MyAdapter(Context ctx, FragmentManager fm) {
+        public PulsePagerAdapter(Context ctx, FragmentManager fm) {
             super(fm);
             mContext = ctx;
         }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -33,7 +33,6 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
 import android.widget.Spinner;
-import android.widget.TextView;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
@@ -64,7 +63,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     @Bind(R.id.content_frame)
     FrameLayout mContentLayout;
 
-    private CountriesSpinnerAdapter mSpinnerAdapter;
+    private ArrayAdapter<String> mSpinnerAdapter;
     private MyAdapter mViewPagerAdapter;
     private ArrayList<String> mPulseTargets;
     private Spinner mSpinner;
@@ -78,7 +77,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
         mPulseTargets = new ArrayList<>();
 
         mViewPagerAdapter = new MyAdapter(this, getSupportFragmentManager());
-        mSpinnerAdapter = new CountriesSpinnerAdapter(this);
+        mSpinnerAdapter = new ArrayAdapter<String>(this, R.layout.spinner_item_actionbar);
 
         App.getInstance().getModelCache().getAsync(Const.CACHE_KEY_PULSE_GLOBAL, true, new ModelCache.CacheListener() {
             @Override
@@ -125,6 +124,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
         });
     }
 
+    @Override
     protected String getTrackedViewName() {
         if (mViewPager == null || mViewPagerAdapter.getSelectedPulseTarget() == null) {
             return "Pulse";
@@ -244,26 +244,6 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
             }
 
             mSelectedPulseTarget = pulseTarget;
-        }
-    }
-
-    private class CountriesSpinnerAdapter extends ArrayAdapter<String> {
-        private final LayoutInflater mInflater;
-
-        public CountriesSpinnerAdapter(Context context) {
-            super(context, android.R.layout.simple_list_item_1, android.R.id.text1);
-            mInflater = LayoutInflater.from(context);
-        }
-
-        @Override
-        public View getView(final int position, final View convertView, final ViewGroup parent) {
-            View view = convertView;
-            if (view == null) {
-                view = mInflater.inflate(R.layout.spinner_item_actionbar, parent, false);
-            }
-            TextView textView = (TextView) view.findViewById(android.R.id.text1);
-            textView.setText(getItem(position));
-            return view;
         }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
@@ -32,6 +32,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 
+import butterknife.Bind;
+import butterknife.ButterKnife;
+
 class PulseAdapter extends BaseAdapter {
 
     private LayoutInflater mInflater;
@@ -65,10 +68,7 @@ class PulseAdapter extends BaseAdapter {
         View rowView = convertView;
         if (rowView == null) {
             rowView = mInflater.inflate(R.layout.list_pulse_item, parent, false);
-            ViewHolder viewHolder = new ViewHolder();
-            viewHolder.position = (TextView) rowView.findViewById(R.id.position);
-            viewHolder.key = (TextView) rowView.findViewById(R.id.key);
-            viewHolder.value = (TextView) rowView.findViewById(R.id.value);
+            ViewHolder viewHolder = new ViewHolder(rowView);
             rowView.setTag(viewHolder);
         }
 
@@ -139,6 +139,15 @@ class PulseAdapter extends BaseAdapter {
     }
 
     static class ViewHolder {
-        public TextView position, key, value;
+        @Bind(R.id.position)
+        public TextView position;
+        @Bind(R.id.key)
+        public TextView key;
+        @Bind(R.id.value)
+        public TextView value;
+
+        public ViewHolder(View v) {
+            ButterKnife.bind(this, v);
+        }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
@@ -81,12 +81,6 @@ public class PulseFragment extends GdgListFragment {
         mTarget = getArguments().getString(ARG_TARGET);
         mMode = getArguments().getInt(ARG_MODE);
 
-        if (getListView() instanceof ListView) {
-            ListView listView = (ListView) getListView();
-            listView.setDivider(null);
-            listView.setDividerHeight(0);
-        }
-
         mAdapter = new PulseAdapter(getActivity());
         setListAdapter(mAdapter);
 

--- a/app/src/main/res/layout-land/fragment_pulse.xml
+++ b/app/src/main/res/layout-land/fragment_pulse.xml
@@ -26,8 +26,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:drawSelectorOnTop="true"
-    android:gravity="top"
-    android:numColumns="3"
+    android:numColumns="2"
     android:stretchMode="columnWidth" />
 
   <include layout="@layout/loading_animated_view" />

--- a/app/src/main/res/layout/fragment_pulse.xml
+++ b/app/src/main/res/layout/fragment_pulse.xml
@@ -25,6 +25,7 @@
     android:id="@android:id/list"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:divider="@null"
     android:drawSelectorOnTop="true" />
 
   <include layout="@layout/loading_animated_view" />

--- a/app/src/main/res/layout/list_pulse_item.xml
+++ b/app/src/main/res/layout/list_pulse_item.xml
@@ -1,49 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:card_view="http://schemas.android.com/apk/res-auto"
+<RelativeLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:orientation="horizontal">
+  android:minHeight="?attr/listPreferredItemHeight"
+  android:orientation="horizontal"
+  tools:layout_height="?attr/listPreferredItemHeight"
+  tools:context=".pulse.PulseActivity">
 
-  <android.support.v7.widget.CardView
-    android:id="@+id/card_view"
+  <TextView
+    android:id="@+id/position"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/keyline_1"
+    android:textAppearance="?attr/textAppearanceListItem"
+    android:layout_centerVertical="true"
+    android:textStyle="bold"
+    tools:text="1."/>
+
+  <TextView
+    android:id="@+id/key"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_centerVertical="true"
+    android:layout_toRightOf="@+id/position"
+    android:layout_marginLeft="4dp"
+    android:textAppearance="?attr/textAppearanceListItem"
+    tools:text="GDG Sampletown"/>
+
+  <TextView
+    android:id="@+id/value"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentRight="true"
+    android:layout_centerVertical="true"
+    android:paddingRight="@dimen/keyline_1"
+    android:textAppearance="?attr/textAppearanceListItem"
+    tools:text="(00)"/>
+
+  <View
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_margin="5dip"
-    android:padding="10dip"
-    card_view:cardCornerRadius="3dp"
-    card_view:contentPadding="10dp">
-
-    <LinearLayout
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:orientation="horizontal">
-
-      <TextView
-        android:id="@+id/position"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|top"
-        tools:text="1."
-        android:textStyle="bold" />
-
-      <TextView
-        android:id="@+id/key"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|top"
-        android:layout_marginLeft="5dip"
-        tools:text="GDG Sampletown" />
-
-      <TextView
-        android:id="@+id/value"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|top"
-        android:gravity="right"
-        tools:text="(00)" />
-    </LinearLayout>
-  </android.support.v7.widget.CardView>
-</LinearLayout>
+    android:layout_height="wrap_content"
+    android:background="?attr/dividerHorizontal"/>
+</RelativeLayout>


### PR DESCRIPTION
Cards are removed from Pulse page. 
What was the opposite of over-cardifying? I've done that. 
Here are the new look. 

Even on Nexus 6, some chapter names were truncated when it was 3 columns no landscape. It is 2 columns now. 

![shamulyz28etasomaniac07272015031114](https://cloud.githubusercontent.com/assets/763339/8896725/dc755076-340d-11e5-9e48-9b95457a3d89.png)
![shamulyz28etasomaniac07272015031120](https://cloud.githubusercontent.com/assets/763339/8896726/dc797cd2-340d-11e5-8919-0d6836a903ac.png)
