### PR TITLE
fix: minor fix in validate input function

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/widget/FeedbackFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/widget/FeedbackFragment.java
@@ -159,19 +159,17 @@ public class FeedbackFragment extends DialogFragment {
 
         if (!TextUtils.isEmpty(strMessage)) {
             isValid = true;
-            mLayoutMessage.setErrorEnabled(false);
+            mLayoutMessage.setError(null);
         } else {
             isValid = false;
-            mLayoutMessage.setErrorEnabled(true);
             mLayoutMessage.setError(getString(R.string.feedback_message_required));
         }
 
         if (!TextUtils.isEmpty(strEmail) && android.util.Patterns.EMAIL_ADDRESS.matcher(strEmail).matches()) {
-            isValid = true;
-            mLayoutEmail.setErrorEnabled(false);
+            isValid = isValid & true;
+            mLayoutEmail.setError(null);
         } else {
-            isValid = false;
-            mLayoutMessage.setErrorEnabled(true);
+            isValid = isValid & false;
             mLayoutEmail.setError(getString(R.string.feedback_invalid_email));
         }
 


### PR DESCRIPTION
- Fixed logic of validating inputs in feedback dialog
- Did minor re-factoring of setting error. Document says "if the error functionality has not been enabled via setErrorEnabled(boolean), then it will be automatically enabled if error is not empty. And If the error is null, the error message will be cleared."