### PR TITLE
GoogleApiClient hopeful memory leak fix. 

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -108,8 +108,6 @@ public abstract class GdgActivity extends TrackableActivity implements
         if (!Utils.isEmulator()) {
 
             mGoogleApiClient = new GoogleApiClient.Builder(this)
-                    .addConnectionCallbacks(this)
-                    .addOnConnectionFailedListener(this)
                     .addApi(Plus.API)
                     .addApi(Games.API)
                     .addApi(AppStateManager.API)
@@ -127,6 +125,9 @@ public abstract class GdgActivity extends TrackableActivity implements
     protected void onStart() {
         super.onStart();
 
+        mGoogleApiClient.registerConnectionCallbacks(this);
+        mGoogleApiClient.registerConnectionFailedListener(this);
+
         if (PrefUtils.isSignedIn(this)) {
             mGoogleApiClient.connect();
         }
@@ -135,6 +136,9 @@ public abstract class GdgActivity extends TrackableActivity implements
     @Override
     protected void onStop() {
         super.onStop();
+
+        mGoogleApiClient.unregisterConnectionCallbacks(this);
+        mGoogleApiClient.unregisterConnectionFailedListener(this);
 
         if (PrefUtils.isSignedIn(this) && mGoogleApiClient.isConnected()) {
             mGoogleApiClient.disconnect();


### PR DESCRIPTION
Listeners are registered in onStart and unregistered in onStop