### PR TITLE
Fix pulse numbering bug. 

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -239,15 +239,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
 
         @Override
         public Fragment getItem(int position) {
-            switch (position) {
-                case 0:
-                    return PulseFragment.newInstance(0, mSelectedPulseTarget);
-                case 1:
-                    return PulseFragment.newInstance(1, mSelectedPulseTarget);
-                case 2:
-                    return PulseFragment.newInstance(2, mSelectedPulseTarget);
-            }
-            return null;
+            return PulseFragment.newInstance(position, mSelectedPulseTarget);
         }
 
         @Override

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -76,10 +76,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
         setContentView(R.layout.activity_pulse);
 
         mPulseTargets = new ArrayList<>();
-
         mViewPagerAdapter = new PulsePagerAdapter(this, getSupportFragmentManager());
-        mSpinnerAdapter = new ArrayAdapter<>(this, R.layout.spinner_item_actionbar);
-        mSpinnerAdapter.setDropDownViewResource(R.layout.support_simple_spinner_dropdown_item);
 
         final String selectedPulse = savedInstanceState != null ? savedInstanceState.getString(INSTANCE_STATE_SELECTED_PULSE) : null;
 
@@ -156,6 +153,9 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     }
 
     private void initSpinner(String selectedPulse) {
+        Collections.sort(mPulseTargets);
+        mPulseTargets.add(0, PulseFragment.GLOBAL);
+
         Toolbar toolbar = getActionBarToolbar();
         View spinnerContainer = LayoutInflater.from(this).inflate(R.layout.actionbar_spinner,
                 toolbar, false);
@@ -164,6 +164,11 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
         toolbar.addView(spinnerContainer, lp);
 
         mSpinner = (Spinner) spinnerContainer.findViewById(R.id.actionbar_spinner);
+
+        mSpinnerAdapter = new ArrayAdapter<>(this, R.layout.spinner_item_actionbar, mPulseTargets);
+        mSpinnerAdapter.setDropDownViewResource(R.layout.support_simple_spinner_dropdown_item);
+        mSpinner.setAdapter(mSpinnerAdapter);
+
         mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(final AdapterView<?> parent, final View view, final int position, final long id) {
@@ -184,21 +189,13 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
 
     private void refreshSpinner(String selectedPulse) {
 
-        mSpinner.setAdapter(mSpinnerAdapter);
-
-        Collections.sort(mPulseTargets);
-        mPulseTargets.add(0, PulseFragment.GLOBAL);
         if (selectedPulse == null) {
             selectedPulse = mPulseTargets.get(0);
         }
-
-        mSpinnerAdapter.clear();
-        mSpinnerAdapter.addAll(mPulseTargets);
         mSpinner.setSelection(mPulseTargets.indexOf(selectedPulse));
 
         mViewPagerAdapter = new PulsePagerAdapter(this, getSupportFragmentManager());
         mViewPagerAdapter.setSelectedPulseTarget(selectedPulse);
-
         mViewPager.setAdapter(mViewPagerAdapter);
         mTabLayout.setupWithViewPager(mViewPager);
     }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -164,15 +164,12 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
         toolbar.addView(spinnerContainer, lp);
 
         mSpinner = (Spinner) spinnerContainer.findViewById(R.id.actionbar_spinner);
-        mSpinner.setAdapter(mSpinnerAdapter);
         mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(final AdapterView<?> parent, final View view, final int position, final long id) {
                 String previous = mViewPagerAdapter.getSelectedPulseTarget();
-                mViewPagerAdapter.setSelectedPulseTarget(mSpinnerAdapter.getItem(position));
                 if (!previous.equals(mSpinnerAdapter.getItem(position))) {
-                    Timber.d("Switching chapter!");
-                    mViewPagerAdapter.notifyDataSetChanged();
+                    refreshSpinner(mSpinnerAdapter.getItem(position));
                 }
             }
 
@@ -182,16 +179,25 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
             }
         });
 
+        refreshSpinner(selectedPulse);
+    }
+
+    private void refreshSpinner(String selectedPulse) {
+
+        mSpinner.setAdapter(mSpinnerAdapter);
+
         Collections.sort(mPulseTargets);
         mPulseTargets.add(0, PulseFragment.GLOBAL);
         if (selectedPulse == null) {
             selectedPulse = mPulseTargets.get(0);
         }
-        mViewPagerAdapter.setSelectedPulseTarget(selectedPulse);
-        mSpinner.setSelection(mPulseTargets.indexOf(selectedPulse));
-        mSpinnerAdapter.clear();
 
+        mSpinnerAdapter.clear();
         mSpinnerAdapter.addAll(mPulseTargets);
+        mSpinner.setSelection(mPulseTargets.indexOf(selectedPulse));
+
+        mViewPagerAdapter = new PulsePagerAdapter(this, getSupportFragmentManager());
+        mViewPagerAdapter.setSelectedPulseTarget(selectedPulse);
 
         mViewPager.setAdapter(mViewPagerAdapter);
         mTabLayout.setupWithViewPager(mViewPager);

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
@@ -43,9 +43,14 @@ class PulseAdapter extends BaseAdapter {
 
     private int mMode;
 
-    public PulseAdapter(Context ctx) {
+    public PulseAdapter(Context ctx, int[] positions) {
         mInflater = LayoutInflater.from(ctx);
         mPulse = new ArrayList<>();
+        mPositions = positions;
+    }
+
+    public int[] getPositions() {
+        return mPositions;
     }
 
     @Override
@@ -117,7 +122,11 @@ class PulseAdapter extends BaseAdapter {
         mMode = mode;
         mPulse.clear();
         mPulse.addAll(pulse.entrySet());
-        mPositions = new int[mPulse.size()];
+        //Only initialize if the positions are not provided.
+        //They are provided in constructor and coming from savedInstanceState of the Fragment.
+        if (mPositions == null || mPositions.length != mPulse.size()) {
+            mPositions = new int[mPulse.size()];
+        }
 
         Collections.sort(mPulse, new Comparator<Map.Entry<String, PulseEntry>>() {
             @Override

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
@@ -39,7 +39,7 @@ class PulseAdapter extends BaseAdapter {
 
     private LayoutInflater mInflater;
     private ArrayList<Map.Entry<String, PulseEntry>> mPulse;
-    private int[] mPosition;
+    private int[] mPositions;
 
     private int mMode;
 
@@ -84,15 +84,15 @@ class PulseAdapter extends BaseAdapter {
                 z++;
             }
             if (z > 2) {
-                mPosition[i] = mPosition[mPulse.indexOf(prevEntry)] + 1;
+                mPositions[i] = mPositions[mPulse.indexOf(prevEntry)] + 1;
             } else {
-                mPosition[i] = mPosition[i - 1] + 1;
+                mPositions[i] = mPositions[i - 1] + 1;
 
             }
-            holder.position.setText(mPosition[i] + ".");
+            holder.position.setText(mPositions[i] + ".");
 
         } else {
-            mPosition[i] = 1;
+            mPositions[i] = 1;
             holder.position.setText("1.");
         }
 
@@ -117,7 +117,7 @@ class PulseAdapter extends BaseAdapter {
         mMode = mode;
         mPulse.clear();
         mPulse.addAll(pulse.entrySet());
-        mPosition = new int[mPulse.size()];
+        mPositions = new int[mPulse.size()];
 
         Collections.sort(mPulse, new Comparator<Map.Entry<String, PulseEntry>>() {
             @Override

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
@@ -17,6 +17,7 @@
 package org.gdg.frisbee.android.pulse;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -43,7 +44,7 @@ class PulseAdapter extends BaseAdapter {
 
     private int mMode;
 
-    public PulseAdapter(Context ctx, int[] positions) {
+    public PulseAdapter(Context ctx, @Nullable int[] positions) {
         mInflater = LayoutInflater.from(ctx);
         mPulse = new ArrayList<>();
         mPositions = positions;

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseAdapter.java
@@ -131,18 +131,7 @@ class PulseAdapter extends BaseAdapter {
         Collections.sort(mPulse, new Comparator<Map.Entry<String, PulseEntry>>() {
             @Override
             public int compare(Map.Entry<String, PulseEntry> entry, Map.Entry<String, PulseEntry> entry2) {
-                PulseEntry value = entry.getValue();
-                PulseEntry value2 = entry2.getValue();
-
-                switch (mode) {
-                    case 0:
-                        return (value.getMeetings() - value2.getMeetings()) * -1;
-                    case 1:
-                        return (value.getAttendees() - value2.getAttendees()) * -1;
-                    case 2:
-                        return (value.getPlusMembers() - value2.getPlusMembers()) * -1;
-                }
-                return 0;
+                return entry.getValue().compareTo(mode, entry2.getValue());
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
@@ -49,6 +49,7 @@ public class PulseFragment extends GdgListFragment {
 
     private static final String ARG_MODE = "mode";
     private static final String ARG_TARGET = "target";
+    private static final String INSTANCE_STATE_POSITIONS = "INSTANCE_STATE_POSITIONS";
 
     private int mMode;
     private String mTarget;
@@ -76,13 +77,21 @@ public class PulseFragment extends GdgListFragment {
     }
 
     @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putIntArray(INSTANCE_STATE_POSITIONS, mAdapter.getPositions());
+    }
+
+    @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
         mTarget = getArguments().getString(ARG_TARGET);
         mMode = getArguments().getInt(ARG_MODE);
 
-        mAdapter = new PulseAdapter(getActivity());
+        int[] positions = savedInstanceState != null
+                ? savedInstanceState.getIntArray(INSTANCE_STATE_POSITIONS) : null;
+        mAdapter = new PulseAdapter(getActivity(), positions);
         setListAdapter(mAdapter);
 
         setIsLoading(true);


### PR DESCRIPTION
The problem is because FragmentStatePagerAdapter was aggressively caching the states of its children Fragments. 
Here is the bug reported and it is still open. https://code.google.com/p/android/issues/detail?id=37990

There are couple of ways to fix it using a really really custom FragmentStatePagerAdapter without subclassing it. I don't like those solutions. It is not optimal but recreating the adapter fixes this problem. 

The problem is actually because of the positions calculation in the code. On orientation change it reset and makes another problem. I saved it on config change and now it works perfectly. 

Fixes #451