### PR TITLE
[WIP] Retrofit 2 integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -215,8 +215,8 @@ dependencies {
     compile "com.squareup.okhttp:logging-interceptor:$rootProject.okHttpVersion"
     compile 'com.squareup.okio:okio:1.6.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'
-    compile 'com.squareup.retrofit:converter-gson:2.0.0-beta2'
+    compile "com.squareup.retrofit:retrofit:$rootProject.retrofitVersion"
+    compile "com.squareup.retrofit:converter-gson:$rootProject.retrofitVersion"
     debugCompile "com.squareup.leakcanary:leakcanary-android:$rootProject.leakCanaryVersion"
     alphaCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
     releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -210,13 +210,13 @@ dependencies {
     compile 'com.google.zxing:core:3.2.1'
 
     //Square
-    compile "com.squareup.okhttp:okhttp:$rootProject.okHttpVersion"
-    compile "com.squareup.okhttp:okhttp-urlconnection:$rootProject.okHttpVersion"
-    compile "com.squareup.okhttp:logging-interceptor:$rootProject.okHttpVersion"
+    compile "com.squareup.okhttp3:okhttp:$rootProject.okHttpVersion"
+    compile "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okHttpVersion"
+    compile "com.squareup.okhttp3:logging-interceptor:$rootProject.okHttpVersion"
     compile 'com.squareup.okio:okio:1.6.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile "com.squareup.retrofit:retrofit:$rootProject.retrofitVersion"
-    compile "com.squareup.retrofit:converter-gson:$rootProject.retrofitVersion"
+    compile "com.squareup.retrofit2:retrofit:$rootProject.retrofitVersion"
+    compile "com.squareup.retrofit2:converter-gson:$rootProject.retrofitVersion"
     debugCompile "com.squareup.leakcanary:leakcanary-android:$rootProject.leakCanaryVersion"
     alphaCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
     releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
@@ -225,6 +225,8 @@ dependencies {
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.jakewharton.timber:timber:4.1.0'
     compile 'com.jakewharton:disklrucache:2.0.2'
+    compile 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.0.1'
+
 
     //Others
     compile 'io.doorbell:android-sdk:0.2.2@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -212,6 +212,7 @@ dependencies {
     //Square
     compile "com.squareup.okhttp:okhttp:$rootProject.okHttpVersion"
     compile "com.squareup.okhttp:okhttp-urlconnection:$rootProject.okHttpVersion"
+    compile "com.squareup.okhttp:logging-interceptor:$rootProject.okHttpVersion"
     compile 'com.squareup.okio:okio:1.6.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -214,8 +214,8 @@ dependencies {
     compile "com.squareup.okhttp:okhttp-urlconnection:$rootProject.okHttpVersion"
     compile 'com.squareup.okio:okio:1.6.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.retrofit:retrofit:2.0.0-beta1'
-    compile 'com.squareup.retrofit:converter-gson:2.0.0-beta1'
+    compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'
+    compile 'com.squareup.retrofit:converter-gson:2.0.0-beta2'
     debugCompile "com.squareup.leakcanary:leakcanary-android:$rootProject.leakCanaryVersion"
     alphaCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
     releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -214,7 +214,8 @@ dependencies {
     compile "com.squareup.okhttp:okhttp-urlconnection:$rootProject.okHttpVersion"
     compile 'com.squareup.okio:okio:1.6.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.retrofit:retrofit:1.9.0'
+    compile 'com.squareup.retrofit:retrofit:2.0.0-beta1'
+    compile 'com.squareup.retrofit:converter-gson:2.0.0-beta1'
     debugCompile "com.squareup.leakcanary:leakcanary-android:$rootProject.leakCanaryVersion"
     alphaCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
     releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"

--- a/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
@@ -21,6 +21,7 @@ import android.support.design.widget.Snackbar;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.ContributorList;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
@@ -28,9 +29,6 @@ import org.gdg.frisbee.android.common.PeopleListFragment;
 import org.gdg.frisbee.android.utils.Utils;
 import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.DateTime;
-
-import retrofit.Callback;
-import retrofit.Response;
 
 public class ContributorsFragment extends PeopleListFragment {
 
@@ -66,19 +64,13 @@ public class ContributorsFragment extends PeopleListFragment {
     private void fetchGitHubContributors() {
         App.getInstance().getGithub().getContributors(Const.GITHUB_ORGA, Const.GITHUB_REPO).enqueue(new Callback<ContributorList>() {
             @Override
-            public void onResponse(Response<ContributorList> response) {
+            public void onSuccessResponse(ContributorList contributors) {
 
-                ContributorList contributors = response.body();
                 mAdapter.addAll(contributors);
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_FRISBEE_CONTRIBUTORS,
                         contributors,
                         DateTime.now().plusDays(1),
                         null);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
@@ -30,7 +30,7 @@ import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.DateTime;
 
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 
 public class ContributorsFragment extends PeopleListFragment {
 
@@ -64,10 +64,11 @@ public class ContributorsFragment extends PeopleListFragment {
     }
     
     private void fetchGitHubContributors() {
-        App.getInstance().getGithub().getContributors(Const.GITHUB_ORGA, Const.GITHUB_REPO, new Callback<ContributorList>() {
+        App.getInstance().getGithub().getContributors(Const.GITHUB_ORGA, Const.GITHUB_REPO).enqueue(new Callback<ContributorList>() {
             @Override
-            public void success(final ContributorList contributors, retrofit.client.Response response) {
+            public void onResponse(Response<ContributorList> response) {
 
+                ContributorList contributors = response.body();
                 mAdapter.addAll(contributors);
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_FRISBEE_CONTRIBUTORS,
                         contributors,
@@ -76,7 +77,7 @@ public class ContributorsFragment extends PeopleListFragment {
             }
 
             @Override
-            public void failure(RetrofitError error) {
+            public void onFailure(Throwable t) {
 
             }
         });

--- a/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
@@ -64,7 +64,7 @@ public class ContributorsFragment extends PeopleListFragment {
     private void fetchGitHubContributors() {
         App.getInstance().getGithub().getContributors(Const.GITHUB_ORGA, Const.GITHUB_REPO).enqueue(new Callback<ContributorList>() {
             @Override
-            public void onSuccessResponse(ContributorList contributors) {
+            public void success(final ContributorList contributors) {
 
                 mAdapter.addAll(contributors);
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_FRISBEE_CONTRIBUTORS,

--- a/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/about/ContributorsFragment.java
@@ -54,8 +54,7 @@ public class ContributorsFragment extends PeopleListFragment {
 
                 @Override
                 public void onNotFound(String key) {
-                    Snackbar snackbar = Snackbar.make(getView(), R.string.offline_alert, Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.alert(snackbar).show();
+                    showError(R.string.offline_alert);
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
@@ -1,0 +1,41 @@
+package org.gdg.frisbee.android.api;
+
+import android.support.annotation.StringRes;
+
+import org.gdg.frisbee.android.R;
+
+import java.io.IOException;
+
+import retrofit.Response;
+import timber.log.Timber;
+
+public abstract class Callback<T> implements retrofit.Callback<T> {
+
+    @Override
+    public final void onResponse(Response<T> response) {
+        if (response.isSuccess())  {
+            onSuccessResponse(response.body());
+        } else {
+            try {
+                final Exception e = new Exception(response.errorBody().string());
+                Timber.e(e, "Network Error!");
+                onFailure(e, R.string.server_error);
+            } catch (IOException e) {
+                Timber.e(e, "Network Error!");
+                onFailure(e, R.string.server_error);
+            }
+        }
+    }
+
+    @Override
+    public final void onFailure(Throwable t) {
+        Timber.d(t, "Network Failure!");
+        onFailure(t, R.string.offline_alert);
+    }
+
+    public void onFailure(Throwable t, @StringRes int errorMessage) {
+    }
+
+    public abstract void onSuccessResponse(T response);
+
+}

--- a/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
@@ -15,15 +15,15 @@ public abstract class Callback<T> implements retrofit.Callback<T> {
     @Override
     public final void onResponse(Response<T> response, Retrofit retrofit) {
         if (response.isSuccess()) {
-            onSuccessResponse(response.body());
+            success(response.body());
         } else {
             try {
                 final Exception e = new Exception(response.errorBody().string());
                 Timber.e(e, "Network Error!");
-                onFailure(e, R.string.server_error);
+                failure(e, R.string.server_error);
             } catch (IOException e) {
                 Timber.e(e, "Network Error!");
-                onFailure(e, R.string.server_error);
+                failure(e, R.string.server_error);
             }
         }
     }
@@ -31,12 +31,12 @@ public abstract class Callback<T> implements retrofit.Callback<T> {
     @Override
     public final void onFailure(Throwable t) {
         Timber.d(t, "Network Failure!");
-        onFailure(t, R.string.offline_alert);
+        failure(t, R.string.offline_alert);
     }
 
-    public void onFailure(Throwable t, @StringRes int errorMessage) {
+    public void failure(Throwable t, @StringRes int errorMessage) {
     }
 
-    public abstract void onSuccessResponse(T response);
+    public abstract void success(T response);
 
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
@@ -1,9 +1,5 @@
 package org.gdg.frisbee.android.api;
 
-import android.support.annotation.StringRes;
-
-import org.gdg.frisbee.android.R;
-
 import java.io.IOException;
 
 import retrofit2.Response;
@@ -19,10 +15,10 @@ public abstract class Callback<T> implements retrofit2.Callback<T> {
             try {
                 final Exception e = new Exception(response.errorBody().string());
                 Timber.e(e, "Network Error!");
-                failure(e, R.string.server_error);
+                failure(e);
             } catch (IOException e) {
                 Timber.e(e, "Network Error!");
-                failure(e, R.string.server_error);
+                failure(e);
             }
         }
     }
@@ -30,10 +26,13 @@ public abstract class Callback<T> implements retrofit2.Callback<T> {
     @Override
     public final void onFailure(Throwable t) {
         Timber.d(t, "Network Failure!");
-        failure(t, R.string.offline_alert);
+        networkFailure(t);
     }
 
-    public void failure(Throwable t, @StringRes int errorMessage) {
+    public void failure(Throwable error) {
+    }
+
+    public void networkFailure(Throwable error) {
     }
 
     public abstract void success(T response);

--- a/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
@@ -7,13 +7,14 @@ import org.gdg.frisbee.android.R;
 import java.io.IOException;
 
 import retrofit.Response;
+import retrofit.Retrofit;
 import timber.log.Timber;
 
 public abstract class Callback<T> implements retrofit.Callback<T> {
 
     @Override
-    public final void onResponse(Response<T> response) {
-        if (response.isSuccess())  {
+    public final void onResponse(Response<T> response, Retrofit retrofit) {
+        if (response.isSuccess()) {
             onSuccessResponse(response.body());
         } else {
             try {

--- a/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/Callback.java
@@ -6,14 +6,13 @@ import org.gdg.frisbee.android.R;
 
 import java.io.IOException;
 
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Response;
 import timber.log.Timber;
 
-public abstract class Callback<T> implements retrofit.Callback<T> {
+public abstract class Callback<T> implements retrofit2.Callback<T> {
 
     @Override
-    public final void onResponse(Response<T> response, Retrofit retrofit) {
+    public final void onResponse(Response<T> response) {
         if (response.isSuccess()) {
             success(response.body());
         } else {

--- a/app/src/main/java/org/gdg/frisbee/android/api/GapiOkTransport.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GapiOkTransport.java
@@ -19,22 +19,12 @@ package org.gdg.frisbee.android.api;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.util.Preconditions;
-import com.google.api.client.util.SecurityUtils;
-import com.google.api.client.util.SslUtils;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
 import java.util.Arrays;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
 
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
@@ -57,48 +47,10 @@ public class GapiOkTransport extends HttpTransport {
         Arrays.sort(SUPPORTED_METHODS);
     }
 
-    /**
-     * HTTP proxy or {@code null} to use the proxy settings from <a
-     * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
-     * properties</a>.
-     */
-    private final Proxy proxy;
     private final OkHttpClient okHttpClient;
 
-    /**
-     * Constructor with the default behavior.
-     *
-     */
-    public GapiOkTransport() {
-        this(new OkHttpClient(), null, null, null);
-    }
-
-    /**
-     * @param proxy HTTP proxy or {@code null} to use the proxy settings from <a
-     *        href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">
-     *        system properties</a>
-     * @param sslSocketFactory SSL socket factory or {@code null} for the default
-     * @param hostnameVerifier host name verifier or {@code null} for the default
-     */
-    GapiOkTransport(
-            OkHttpClient okHttpClient,
-            Proxy proxy, SSLSocketFactory sslSocketFactory, HostnameVerifier hostnameVerifier) {
-        OkHttpClient.Builder builder = okHttpClient.newBuilder();
-        this.proxy = proxy;
-
-        SSLContext sslContext;
-        try {
-            sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, null, null);
-        } catch (GeneralSecurityException e) {
-            throw new AssertionError(); // The system has no TLS. Just give up.
-        }
-        builder.sslSocketFactory(sslContext.getSocketFactory());
-
-        if (proxy != null) {
-            builder.proxy(proxy);
-        }
-        this.okHttpClient = builder.build();
+    public GapiOkTransport(OkHttpClient okHttpClient) {
+        this.okHttpClient = okHttpClient;
     }
 
     @Override
@@ -118,160 +70,5 @@ public class GapiOkTransport extends HttpTransport {
         connection.setRequestMethod(method);
 
         return new GapiOkHttpRequest(connection);
-    }
-
-    /**
-     * Builder for {@link GapiOkTransport}.
-     *
-     * <p>
-     * Implementation is not thread-safe.
-     * </p>
-     *
-     * @since 1.13
-     */
-    public static final class Builder {
-
-        /** SSL socket factory or {@code null} for the default. */
-        private SSLSocketFactory sslSocketFactory;
-
-        /** Host name verifier or {@code null} for the default. */
-        private HostnameVerifier hostnameVerifier;
-
-        /**
-         * HTTP proxy or {@code null} to use the proxy settings from <a
-         * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
-         * properties</a>.
-         */
-        private Proxy proxy;
-
-        /**
-         * OkHttpClient to be used. If it is not available, the default client will be initialized.
-         */
-        private OkHttpClient okHttpClient;
-
-        /**
-         * Sets the HTTP proxy or {@code null} to use the proxy settings from <a
-         * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
-         * properties</a>.
-         *
-         * <p>
-         * For example:
-         * </p>
-         *
-         * <pre>
-         setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8080)))
-         * </pre>
-         */
-        public Builder setProxy(Proxy proxy) {
-            this.proxy = proxy;
-            return this;
-        }
-
-        public Builder setOkHttpClient(OkHttpClient okHttpClient) {
-            this.okHttpClient = okHttpClient;
-            return this;
-        }
-
-        /**
-         * Sets the SSL socket factory based on root certificates in a Java KeyStore.
-         *
-         * <p>
-         * Example usage:
-         * </p>
-         *
-         * <pre>
-         trustCertificatesFromJavaKeyStore(new FileInputStream("certs.jks"), "password");
-         * </pre>
-         *
-         * @param keyStoreStream input stream to the key store (closed at the end of this method in a
-         *        finally block)
-         * @param storePass password protecting the key store file
-         * @since 1.14
-         */
-        public Builder trustCertificatesFromJavaKeyStore(InputStream keyStoreStream, String storePass)
-            throws GeneralSecurityException, IOException {
-            KeyStore trustStore = SecurityUtils.getJavaKeyStore();
-            SecurityUtils.loadKeyStore(trustStore, keyStoreStream, storePass);
-            return trustCertificates(trustStore);
-        }
-
-        /**
-         * Sets the SSL socket factory based root certificates generated from the specified stream using
-         *
-         * <p>
-         * Example usage:
-         * </p>
-         *
-         * <pre>
-         trustCertificatesFromStream(new FileInputStream("certs.pem"));
-         * </pre>
-         *
-         * @param certificateStream certificate stream
-         * @since 1.14
-         */
-        public Builder trustCertificatesFromStream(InputStream certificateStream)
-            throws GeneralSecurityException, IOException {
-            KeyStore trustStore = SecurityUtils.getJavaKeyStore();
-            trustStore.load(null, null);
-            SecurityUtils.loadKeyStoreFromCertificates(
-                    trustStore, SecurityUtils.getX509CertificateFactory(), certificateStream);
-            return trustCertificates(trustStore);
-        }
-
-        /**
-         * Sets the SSL socket factory based on a root certificate trust store.
-         *
-         * @param trustStore certificate trust store (use for example {@link SecurityUtils#loadKeyStore}
-         *        or {@link SecurityUtils#loadKeyStoreFromCertificates})
-         * @since 1.14
-         */
-        public Builder trustCertificates(KeyStore trustStore) throws GeneralSecurityException {
-            SSLContext sslContext = SslUtils.getTlsSslContext();
-            SslUtils.initSslContext(sslContext, trustStore, SslUtils.getPkixTrustManagerFactory());
-            return setSslSocketFactory(sslContext.getSocketFactory());
-        }
-
-        /**
-         * Disables validating server SSL certificates by setting the SSL socket factory using
-         * {@link SslUtils#trustAllSSLContext()} for the SSL context and
-         * {@link SslUtils#trustAllHostnameVerifier()} for the host name verifier.
-         *
-         * <p>
-         * Be careful! Disabling certificate validation is dangerous and should only be done in testing
-         * environments.
-         * </p>
-         */
-        public Builder doNotValidateCertificate() throws GeneralSecurityException {
-            hostnameVerifier = SslUtils.trustAllHostnameVerifier();
-            sslSocketFactory = SslUtils.trustAllSSLContext().getSocketFactory();
-            return this;
-        }
-
-        /** Returns the SSL socket factory. */
-        public SSLSocketFactory getSslSocketFactory() {
-            return sslSocketFactory;
-        }
-
-        /** Sets the SSL socket factory or {@code null} for the default. */
-        public Builder setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
-            this.sslSocketFactory = sslSocketFactory;
-            return this;
-        }
-
-        /** Returns the host name verifier or {@code null} for the default. */
-        public HostnameVerifier getHostnameVerifier() {
-            return hostnameVerifier;
-        }
-
-        /** Sets the host name verifier or {@code null} for the default. */
-        public Builder setHostnameVerifier(HostnameVerifier hostnameVerifier) {
-            this.hostnameVerifier = hostnameVerifier;
-            return this;
-        }
-
-        /** Returns a new instance of {@link GapiOkTransport} based on the options. */
-        public GapiOkTransport build() {
-            return new GapiOkTransport(okHttpClient, proxy, sslSocketFactory, hostnameVerifier);
-        }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectory.java
@@ -2,11 +2,11 @@ package org.gdg.frisbee.android.api;
 
 import org.gdg.frisbee.android.api.model.GdeList;
 
-import retrofit.Callback;
+import retrofit.Call;
 import retrofit.http.GET;
 
 public interface GdeDirectory {
     
-    @GET("/gde/list")
-    void getDirectory(Callback<GdeList> callback);
+    @GET("gde/list")
+    Call<GdeList> getDirectory();
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectory.java
@@ -2,8 +2,8 @@ package org.gdg.frisbee.android.api;
 
 import org.gdg.frisbee.android.api.model.GdeList;
 
-import retrofit.Call;
-import retrofit.http.GET;
+import retrofit2.Call;
+import retrofit2.http.GET;
 
 public interface GdeDirectory {
     

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectoryFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectoryFactory.java
@@ -2,34 +2,24 @@ package org.gdg.frisbee.android.api;
 
 import com.google.gson.FieldNamingPolicy;
 
-import org.gdg.frisbee.android.BuildConfig;
+import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.Utils;
 
-import retrofit.RestAdapter;
-import retrofit.converter.GsonConverter;
+import retrofit.GsonConverterFactory;
+import retrofit.Retrofit;
 
-/**
- * Created by <a href="mailto:marcusandreog@gmail.com">Marcus Gabilheri</a>
- *
- * @author Marcus Gabilheri
- * @version 1.0
- * @since 7/28/15.
- */
 public class GdeDirectoryFactory {
 
-    // This variable is meant to be changed as pleased while debugging
-    private static final RestAdapter.LogLevel LOG_LEVEL = RestAdapter.LogLevel.NONE;
     private static final String API_URL = "https://gde-map.appspot.com";
 
     private GdeDirectoryFactory() {
     }
 
-    private static RestAdapter provideRestAdapter() {
-        return new RestAdapter.Builder()
-                .setEndpoint(API_URL)
-                .setClient(OkClientFactory.provideClient())
-                .setLogLevel(BuildConfig.DEBUG ? LOG_LEVEL : RestAdapter.LogLevel.NONE)
-                .setConverter(new GsonConverter(Utils.getGson(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)))
+    private static Retrofit provideRestAdapter() {
+        return new Retrofit.Builder()
+                .baseUrl(API_URL)
+                .client(App.getInstance().getOkHttpClient())
+                .addConverterFactory(GsonConverterFactory.create(Utils.getGson(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)))
                 .build();
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectoryFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdeDirectoryFactory.java
@@ -5,8 +5,8 @@ import com.google.gson.FieldNamingPolicy;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.Utils;
 
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import retrofit2.GsonConverterFactory;
+import retrofit2.Retrofit;
 
 public class GdeDirectoryFactory {
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgXHub.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgXHub.java
@@ -10,7 +10,7 @@ import org.gdg.frisbee.android.api.model.PagedList;
 import org.gdg.frisbee.android.api.model.TaggedEvent;
 import org.joda.time.DateTime;
 
-import retrofit.Callback;
+import retrofit.Call;
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.Header;
@@ -21,35 +21,29 @@ import retrofit.http.Query;
 
 public interface GdgXHub {
 
-    @GET("/chapters?perpage=-1")
-    void getDirectory(Callback<Directory> callback);
+    @GET("chapters?perpage=-1")
+    Call<Directory> getDirectory();
 
-    @GET("/events/{id}")
-    void getEventDetail(@Path("id") String eventId,
-                        Callback<EventFullDetails> callback);
+    @GET("events/{id}")
+    Call<EventFullDetails> getEventDetail(@Path("id") String eventId);
 
-    @GET("/events/tag/{tag}/upcoming?perpage=-1")
-    void getTaggedEventUpcomingList(@Path("tag") String tag,
-                                    @Query("_") DateTime now,
-                                    Callback<PagedList<TaggedEvent>> callback);
+    @GET("events/tag/{tag}/upcoming?perpage=-1")
+    Call<PagedList<TaggedEvent>> getTaggedEventUpcomingList(@Path("tag") String tag,
+                                    @Query("_") DateTime now);
 
-    @POST("/frisbee/gcm/register")
-    void registerGcm(@Header("Authorization") String authorization,
-                     @Body GcmRegistrationRequest request,
-                     Callback<GcmRegistrationResponse> callback);
+    @POST("frisbee/gcm/register")
+    Call<GcmRegistrationResponse> registerGcm(@Header("Authorization") String authorization,
+                     @Body GcmRegistrationRequest request);
 
-    @POST("/frisbee/gcm/unregister")
-    void unregisterGcm(@Header("Authorization") String authorization,
-                       @Body GcmRegistrationRequest request,
-                       Callback<GcmRegistrationResponse> callback);
+    @POST("frisbee/gcm/unregister")
+    Call<GcmRegistrationResponse> unregisterGcm(@Header("Authorization") String authorization,
+                       @Body GcmRegistrationRequest request);
 
-    @PUT("/frisbee/user/home")
-    void setHomeGdg(@Header("Authorization") String authorization,
-                    @Body HomeGdgRequest request,
-                    Callback<Void> callback);
+    @PUT("frisbee/user/home")
+    Call<Void> setHomeGdg(@Header("Authorization") String authorization,
+                    @Body HomeGdgRequest request);
 
-    @GET("/organizer/{gplusId}")
-    void checkOrganizer(@Path("gplusId") String gplusId,
-                        Callback<OrganizerCheckResponse> callback);
+    @GET("organizer/{gplusId}")
+    Call<OrganizerCheckResponse> checkOrganizer(@Path("gplusId") String gplusId);
 
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgXHub.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgXHub.java
@@ -10,14 +10,14 @@ import org.gdg.frisbee.android.api.model.PagedList;
 import org.gdg.frisbee.android.api.model.TaggedEvent;
 import org.joda.time.DateTime;
 
-import retrofit.Call;
-import retrofit.http.Body;
-import retrofit.http.GET;
-import retrofit.http.Header;
-import retrofit.http.POST;
-import retrofit.http.PUT;
-import retrofit.http.Path;
-import retrofit.http.Query;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.POST;
+import retrofit2.http.PUT;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 public interface GdgXHub {
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgXHubFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgXHubFactory.java
@@ -2,35 +2,25 @@ package org.gdg.frisbee.android.api;
 
 import com.google.gson.FieldNamingPolicy;
 
-import org.gdg.frisbee.android.BuildConfig;
 import org.gdg.frisbee.android.api.deserializer.ZuluDateTimeDeserializer;
+import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.Utils;
 
-import retrofit.RestAdapter;
-import retrofit.converter.GsonConverter;
+import retrofit.GsonConverterFactory;
+import retrofit.Retrofit;
 
-/**
- * Created by <a href="mailto:marcusandreog@gmail.com">Marcus Gabilheri</a>
- *
- * @author Marcus Gabilheri
- * @version 1.0
- * @since 7/26/15.
- */
 public final class GdgXHubFactory {
 
-    // This variable is meant to be changed as pleased while debugging
-    private static final RestAdapter.LogLevel LOG_LEVEL = RestAdapter.LogLevel.NONE;
-    private static final String BASE_URL = "https://hub.gdgx.io/api/v1";
+    private static final String BASE_URL = "https://hub.gdgx.io/api/v1/";
 
     private GdgXHubFactory() {
     }
 
-    private static RestAdapter provideRestAdapter() {
-        return new RestAdapter.Builder()
-                .setEndpoint(BASE_URL)
-                .setClient(OkClientFactory.provideClient())
-                .setLogLevel(BuildConfig.DEBUG ? LOG_LEVEL : RestAdapter.LogLevel.NONE)
-                .setConverter(new GsonConverter(Utils.getGson(FieldNamingPolicy.IDENTITY, new ZuluDateTimeDeserializer())))
+    private static Retrofit provideRestAdapter() {
+        return new Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(App.getInstance().getOkHttpClient())
+                .addConverterFactory(GsonConverterFactory.create(Utils.getGson(FieldNamingPolicy.IDENTITY, new ZuluDateTimeDeserializer())))
                 .build();
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GdgXHubFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GdgXHubFactory.java
@@ -6,8 +6,8 @@ import org.gdg.frisbee.android.api.deserializer.ZuluDateTimeDeserializer;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.Utils;
 
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import retrofit2.GsonConverterFactory;
+import retrofit2.Retrofit;
 
 public final class GdgXHubFactory {
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
@@ -18,17 +18,13 @@ package org.gdg.frisbee.android.api;
 
 import org.gdg.frisbee.android.api.model.ContributorList;
 
-import retrofit.Callback;
+import retrofit.Call;
 import retrofit.http.GET;
 import retrofit.http.Path;
 
 public interface GitHub {
 
-    @GET("/repos/{owner}/{repo}/contributors")
-    void getContributors(@Path("owner") String user, 
-                         @Path("repo") String repo,
-                         Callback<ContributorList> callback);
-
-//    @GET("/users/{username}")
-//    void getUserDetail(@Path("username") String username, Callback<EventFullDetails> callback);
+    @GET("repos/{owner}/{repo}/contributors")
+    Call<ContributorList> getContributors(@Path("owner") String user,
+                         @Path("repo") String repo);
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GitHub.java
@@ -18,9 +18,9 @@ package org.gdg.frisbee.android.api;
 
 import org.gdg.frisbee.android.api.model.ContributorList;
 
-import retrofit.Call;
-import retrofit.http.GET;
-import retrofit.http.Path;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
 
 public interface GitHub {
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GithubFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GithubFactory.java
@@ -2,34 +2,26 @@ package org.gdg.frisbee.android.api;
 
 import com.google.gson.FieldNamingPolicy;
 
-import org.gdg.frisbee.android.BuildConfig;
+import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.Utils;
 
-import retrofit.RestAdapter;
-import retrofit.converter.GsonConverter;
+import retrofit.GsonConverterFactory;
+import retrofit.Retrofit;
 
-/**
- * Created by <a href="mailto:marcusandreog@gmail.com">Marcus Gabilheri</a>
- *
- * @author Marcus Gabilheri
- * @version 1.0
- * @since 7/28/15.
- */
 public class GithubFactory {
 
     // This variable is meant to be changed as pleased while debugging
-    private static final RestAdapter.LogLevel LOG_LEVEL = RestAdapter.LogLevel.NONE;
+//    private static final RestAdapter.LogLevel LOG_LEVEL = RestAdapter.LogLevel.NONE;
     private static final String API_URL = "https://api.github.com";
 
     private GithubFactory() {
     }
 
-    private static RestAdapter provideRestAdapter() {
-        return new RestAdapter.Builder()
-                .setEndpoint(API_URL)
-                .setLogLevel(BuildConfig.DEBUG ? LOG_LEVEL : RestAdapter.LogLevel.NONE)
-                .setConverter(new GsonConverter(Utils.getGson(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)))
-                .setClient(OkClientFactory.provideClient())
+    private static Retrofit provideRestAdapter() {
+        return new Retrofit.Builder()
+                .baseUrl(API_URL)
+                .addConverterFactory(GsonConverterFactory.create(Utils.getGson(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)))
+                .client(App.getInstance().getOkHttpClient())
                 .build();
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GithubFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GithubFactory.java
@@ -10,8 +10,6 @@ import retrofit.Retrofit;
 
 public class GithubFactory {
 
-    // This variable is meant to be changed as pleased while debugging
-//    private static final RestAdapter.LogLevel LOG_LEVEL = RestAdapter.LogLevel.NONE;
     private static final String API_URL = "https://api.github.com";
 
     private GithubFactory() {
@@ -25,7 +23,6 @@ public class GithubFactory {
                 .build();
     }
 
-    // this client is not used enough to justify making it a singleton
     public static GitHub provideGitHubApi() {
         return provideRestAdapter().create(GitHub.class);
     }

--- a/app/src/main/java/org/gdg/frisbee/android/api/GithubFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GithubFactory.java
@@ -5,8 +5,8 @@ import com.google.gson.FieldNamingPolicy;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.Utils;
 
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import retrofit2.GsonConverterFactory;
+import retrofit2.Retrofit;
 
 public class GithubFactory {
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectory.java
@@ -21,22 +21,21 @@ import org.gdg.frisbee.android.api.model.Pulse;
 
 import java.util.ArrayList;
 
-import retrofit.Callback;
+import retrofit.Call;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
 
 public interface GroupDirectory {
 
-    @GET("/groups/pulse_stats/")
-    void getPulse(Callback<Pulse> callback);
+    @GET("groups/pulse_stats/")
+    Call<Pulse> getPulse();
 
-    @GET("/groups/pulse_stats/{country}/")
-    void getCountryPulse(@Path("country") String country, Callback<Pulse> callback);
+    @GET("groups/pulse_stats/{country}/")
+    Call<Pulse> getCountryPulse(@Path("country") String country);
 
-    @GET("/events/feed/json")
-    void getChapterEventList(@Query("start") final int start,
+    @GET("events/feed/json")
+    Call<ArrayList<Event>> getChapterEventList(@Query("start") final int start,
                              @Query("end") final int end,
-                             @Query("group") final String chapterId,
-                             Callback<ArrayList<Event>> callback);
+                             @Query("group") final String chapterId);
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectory.java
@@ -21,10 +21,10 @@ import org.gdg.frisbee.android.api.model.Pulse;
 
 import java.util.ArrayList;
 
-import retrofit.Call;
-import retrofit.http.GET;
-import retrofit.http.Path;
-import retrofit.http.Query;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 public interface GroupDirectory {
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectoryFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/GroupDirectoryFactory.java
@@ -1,17 +1,16 @@
 package org.gdg.frisbee.android.api;
 
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
-
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.Utils;
 
 import java.io.IOException;
 
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import retrofit2.GsonConverterFactory;
+import retrofit2.Retrofit;
 
 public final class GroupDirectoryFactory {
 
@@ -21,26 +20,25 @@ public final class GroupDirectoryFactory {
     }
 
     private static Retrofit provideRestAdapter() {
-        OkHttpClient client = App.getInstance().getOkHttpClient().clone();
-        client.interceptors().add(new Interceptor() {
+        OkHttpClient.Builder client = App.getInstance().getOkHttpClient().newBuilder();
+        client.addInterceptor(new Interceptor() {
             @Override
             public Response intercept(Chain chain) throws IOException {
 
                 Request compressedRequest = chain.request().newBuilder()
                         .header("User-Agent", "GDG-Frisbee/0.1 (Android)")
-                        .header("Referer", "https://developers.google.com/groups/directory/")
+                        .header("Referrer", "https://developers.google.com/groups/directory/")
                         .header("X-Requested-With", "XMLHttpRequest")
                         .header("Cache-Control", "no-cache")
                         .header("DNT", "1")
                         .build();
                 return chain.proceed(compressedRequest);
-
             }
         });
         return new Retrofit.Builder()
                     .baseUrl(BASE_URL)
                     .addConverterFactory(GsonConverterFactory.create(Utils.getGson()))
-                    .client(client)
+                    .client(client.build())
                     .build();
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
@@ -4,9 +4,17 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.squareup.okhttp.Cache;
+import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import org.gdg.frisbee.android.BuildConfig;
 
 import java.io.File;
+import java.io.IOException;
+
+import timber.log.Timber;
 
 public final class OkClientFactory {
 
@@ -23,6 +31,28 @@ public final class OkClientFactory {
         File cacheDir = new File(context.getApplicationContext().getCacheDir(), "http");
         Cache cache = new Cache(cacheDir, DISK_CACHE_SIZE);
         okHttpClient.setCache(cache);
+        if (BuildConfig.DEBUG) {
+            okHttpClient.interceptors().add(new LoggingInterceptor());
+        }
         return okHttpClient;
+    }
+
+    private static class LoggingInterceptor implements Interceptor {
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            Request request = chain.request();
+
+            long t1 = System.nanoTime();
+            Timber.i(String.format("Sending request %s on %s%n%s",
+                    request.url(), chain.connection(), request.headers()));
+
+            Response response = chain.proceed(request);
+
+            long t2 = System.nanoTime();
+            Timber.i(String.format("Received response for %s in %.1fms%n%s",
+                    response.request().url(), (t2 - t1) / 1e6d, response.headers()));
+
+            return response;
+        }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
@@ -43,8 +43,8 @@ public final class OkClientFactory {
             Request request = chain.request();
 
             long t1 = System.nanoTime();
-            Timber.i(String.format("Sending request %s on %s%n%s",
-                    request.url(), chain.connection(), request.headers()));
+            Timber.i(String.format("Sending request %s on %s",
+                    request.url(), chain.connection()));
 
             Response response = chain.proceed(request);
 

--- a/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
@@ -4,15 +4,12 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.squareup.okhttp.Cache;
-import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor;
 
 import org.gdg.frisbee.android.BuildConfig;
 
 import java.io.File;
-import java.io.IOException;
 
 import timber.log.Timber;
 
@@ -32,27 +29,15 @@ public final class OkClientFactory {
         Cache cache = new Cache(cacheDir, DISK_CACHE_SIZE);
         okHttpClient.setCache(cache);
         if (BuildConfig.DEBUG) {
-            okHttpClient.interceptors().add(new LoggingInterceptor());
+            HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(new HttpLoggingInterceptor.Logger() {
+                @Override
+                public void log(String message) {
+                    Timber.tag("OkHttp").v(message);
+                }
+            });
+            loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            okHttpClient.interceptors().add(loggingInterceptor);
         }
         return okHttpClient;
-    }
-
-    private static class LoggingInterceptor implements Interceptor {
-        @Override
-        public Response intercept(Chain chain) throws IOException {
-            Request request = chain.request();
-
-            long t1 = System.nanoTime();
-            Timber.i(String.format("Sending request %s on %s",
-                    request.url(), chain.connection()));
-
-            Response response = chain.proceed(request);
-
-            long t2 = System.nanoTime();
-            Timber.i(String.format("Received response for %s in %.1fms%n%s",
-                    response.request().url(), (t2 - t1) / 1e6d, response.headers()));
-
-            return response;
-        }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
@@ -1,16 +1,15 @@
 package org.gdg.frisbee.android.api;
 
-import android.content.Context;
+import android.app.Application;
 import android.support.annotation.NonNull;
-
-import com.squareup.okhttp.Cache;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.logging.HttpLoggingInterceptor;
 
 import org.gdg.frisbee.android.BuildConfig;
 
 import java.io.File;
 
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
 import timber.log.Timber;
 
 public final class OkClientFactory {
@@ -22,12 +21,13 @@ public final class OkClientFactory {
     }
 
     @NonNull
-    public static OkHttpClient provideOkHttpClient(Context context) {
-        OkHttpClient okHttpClient = new OkHttpClient();
+    public static OkHttpClient provideOkHttpClient(Application app) {
         // Install an HTTP cache in the application cache directory.
-        File cacheDir = new File(context.getApplicationContext().getCacheDir(), "http");
+        File cacheDir = new File(app.getCacheDir(), "http");
         Cache cache = new Cache(cacheDir, DISK_CACHE_SIZE);
-        okHttpClient.setCache(cache);
+
+        OkHttpClient.Builder okHttpClient = new OkHttpClient.Builder()
+                .cache(cache);
         if (BuildConfig.DEBUG) {
             HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(new HttpLoggingInterceptor.Logger() {
                 @Override
@@ -36,8 +36,8 @@ public final class OkClientFactory {
                 }
             });
             loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-            okHttpClient.interceptors().add(loggingInterceptor);
+            okHttpClient.addInterceptor(loggingInterceptor);
         }
-        return okHttpClient;
+        return okHttpClient.build();
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/OkClientFactory.java
@@ -6,12 +6,7 @@ import android.support.annotation.NonNull;
 import com.squareup.okhttp.Cache;
 import com.squareup.okhttp.OkHttpClient;
 
-import org.gdg.frisbee.android.app.App;
-
 import java.io.File;
-
-import retrofit.client.Client;
-import retrofit.client.OkClient;
 
 public final class OkClientFactory {
 
@@ -29,10 +24,5 @@ public final class OkClientFactory {
         Cache cache = new Cache(cacheDir, DISK_CACHE_SIZE);
         okHttpClient.setCache(cache);
         return okHttpClient;
-    }
-
-    @NonNull
-    public static Client provideClient() {
-        return new OkClient(App.getInstance().getOkHttpClient());
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/api/PlusPersonDownloader.java
+++ b/app/src/main/java/org/gdg/frisbee/android/api/PlusPersonDownloader.java
@@ -4,9 +4,6 @@ import android.support.annotation.Nullable;
 
 import com.google.api.services.plus.Plus;
 import com.google.api.services.plus.model.Person;
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.app.App;
@@ -16,11 +13,11 @@ import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
 import timber.log.Timber;
 
-/**
- * Created by Said Tahsin Dane on 27/7/15.
- */
 public class PlusPersonDownloader implements Interceptor {
 
     private static final Pattern mPlusPattern
@@ -35,7 +32,7 @@ public class PlusPersonDownloader implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
 
-        Matcher matcher = mPlusPattern.matcher(request.urlString());
+        Matcher matcher = mPlusPattern.matcher(request.url().toString());
         if (!matcher.matches()) {
             return chain.proceed(request);
         }

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -35,11 +35,10 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.plus.Plus;
+import com.jakewharton.picasso.OkHttp3Downloader;
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
-import com.squareup.okhttp.OkHttpClient;
 import com.squareup.picasso.LruCache;
-import com.squareup.picasso.OkHttpDownloader;
 import com.squareup.picasso.Picasso;
 
 import net.danlew.android.joda.JodaTimeAndroid;
@@ -70,6 +69,7 @@ import java.io.File;
 import java.util.ArrayList;
 
 import io.fabric.sdk.android.Fabric;
+import okhttp3.OkHttpClient;
 import timber.log.Timber;
 
 public class App extends BaseApp implements LocationListener {
@@ -150,14 +150,13 @@ public class App extends BaseApp implements LocationListener {
         // When we clone mOkHttpClient, it will use all the same cache and everything.
         // Only the interceptors will be different.
         // We shouldn't have the below interceptor in other instances.
-        OkHttpClient picassoClient = mOkHttpClient.clone();
-        picassoClient.interceptors().add(new PlusPersonDownloader(plusClient));
+        OkHttpClient.Builder picassoClient = mOkHttpClient.newBuilder();
+        picassoClient.addInterceptor(new PlusPersonDownloader(plusClient));
 
         mPicasso = new Picasso.Builder(this)
-                .downloader(new OkHttpDownloader(picassoClient))
+                .downloader(new OkHttp3Downloader(picassoClient.build()))
                 .memoryCache(new LruCache(this))
                 .build();
-//        mPicasso.setIndicatorsEnabled(BuildConfig.DEBUG);
 
         JodaTimeAndroid.init(this);
 

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -131,9 +131,7 @@ public class App extends BaseApp implements LocationListener {
         mOkHttpClient = OkClientFactory.provideOkHttpClient(this);
 
         //Initialize Plus Client which is used to get profile pictures and NewFeed of the chapters.
-        final HttpTransport mTransport = new GapiOkTransport.Builder()
-                .setOkHttpClient(mOkHttpClient)
-                .build();
+        final HttpTransport mTransport = new GapiOkTransport(mOkHttpClient);
         final JsonFactory mJsonFactory = new GsonFactory();
         plusClient = new Plus.Builder(mTransport, mJsonFactory, null)
                 .setGoogleClientRequestInitializer(

--- a/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
@@ -11,7 +11,7 @@ import org.gdg.frisbee.android.api.model.OrganizerCheckResponse;
 import org.gdg.frisbee.android.utils.PrefUtils;
 
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 
 public class OrganizerChecker {
     private boolean mIsOrganizer = false;
@@ -53,19 +53,19 @@ public class OrganizerChecker {
                 && (!currentId.equals(mCheckedId)
                 || System.currentTimeMillis() > mLastOrganizerCheck + Const.ORGANIZER_CHECK_MAX_TIME)) {
             mIsOrganizer = false;
-            App.getInstance().getGdgXHub().checkOrganizer(currentId, new Callback<OrganizerCheckResponse>() {
+            App.getInstance().getGdgXHub().checkOrganizer(currentId).enqueue(new Callback<OrganizerCheckResponse>() {
                 @Override
-                public void success(OrganizerCheckResponse organizerCheckResponse, retrofit.client.Response response) {
+                public void onResponse(Response<OrganizerCheckResponse> response) {
                     mLastOrganizerCheck = System.currentTimeMillis();
                     mCheckedId = currentId;
-                    mIsOrganizer = organizerCheckResponse.getChapters().size() > 0;
+                    mIsOrganizer = response.body().getChapters().size() > 0;
                     responseHandler.onOrganizerResponse(mIsOrganizer);
 
                     savePreferences();
                 }
 
                 @Override
-                public void failure(RetrofitError error) {
+                public void onFailure(Throwable t) {
                     mIsOrganizer = false;
                     responseHandler.onErrorResponse();
                 }

--- a/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
@@ -7,11 +7,9 @@ import com.google.android.gms.plus.Plus;
 import com.google.android.gms.plus.model.people.Person;
 
 import org.gdg.frisbee.android.Const;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.OrganizerCheckResponse;
 import org.gdg.frisbee.android.utils.PrefUtils;
-
-import retrofit.Callback;
-import retrofit.Response;
 
 public class OrganizerChecker {
     private boolean mIsOrganizer = false;
@@ -55,17 +53,17 @@ public class OrganizerChecker {
             mIsOrganizer = false;
             App.getInstance().getGdgXHub().checkOrganizer(currentId).enqueue(new Callback<OrganizerCheckResponse>() {
                 @Override
-                public void onResponse(Response<OrganizerCheckResponse> response) {
+                public void onSuccessResponse(OrganizerCheckResponse response) {
                     mLastOrganizerCheck = System.currentTimeMillis();
                     mCheckedId = currentId;
-                    mIsOrganizer = response.body().getChapters().size() > 0;
+                    mIsOrganizer = response.getChapters().size() > 0;
                     responseHandler.onOrganizerResponse(mIsOrganizer);
 
                     savePreferences();
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable t, int errorMessage) {
                     mIsOrganizer = false;
                     responseHandler.onErrorResponse();
                 }

--- a/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
@@ -63,7 +63,7 @@ public class OrganizerChecker {
                 }
 
                 @Override
-                public void failure(Throwable t, int errorMessage) {
+                public void failure(Throwable error) {
                     mIsOrganizer = false;
                     responseHandler.onErrorResponse();
                 }

--- a/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/OrganizerChecker.java
@@ -53,17 +53,17 @@ public class OrganizerChecker {
             mIsOrganizer = false;
             App.getInstance().getGdgXHub().checkOrganizer(currentId).enqueue(new Callback<OrganizerCheckResponse>() {
                 @Override
-                public void onSuccessResponse(OrganizerCheckResponse response) {
+                public void success(OrganizerCheckResponse organizerCheckResponse) {
                     mLastOrganizerCheck = System.currentTimeMillis();
                     mCheckedId = currentId;
-                    mIsOrganizer = response.getChapters().size() > 0;
+                    mIsOrganizer = organizerCheckResponse.getChapters().size() > 0;
                     responseHandler.onOrganizerResponse(mIsOrganizer);
 
                     savePreferences();
                 }
 
                 @Override
-                public void onFailure(Throwable t, int errorMessage) {
+                public void failure(Throwable t, int errorMessage) {
                     mIsOrganizer = false;
                     responseHandler.onErrorResponse();
                 }

--- a/app/src/main/java/org/gdg/frisbee/android/appwidget/GdgDashClockExtension.java
+++ b/app/src/main/java/org/gdg/frisbee/android/appwidget/GdgDashClockExtension.java
@@ -7,6 +7,7 @@ import com.google.android.apps.dashclock.api.DashClockExtension;
 import com.google.android.apps.dashclock.api.ExtensionData;
 
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Event;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.PrefUtils;
@@ -15,8 +16,6 @@ import org.joda.time.format.DateTimeFormat;
 
 import java.util.ArrayList;
 
-import retrofit.Callback;
-import retrofit.Response;
 import timber.log.Timber;
 
 public class GdgDashClockExtension extends DashClockExtension {
@@ -36,8 +35,7 @@ public class GdgDashClockExtension extends DashClockExtension {
                 homeGdg)
                 .enqueue(new Callback<ArrayList<Event>>() {
                     @Override
-                    public void onResponse(Response<ArrayList<Event>> response) {
-                        ArrayList<Event> events = response.body();
+                    public void onSuccessResponse(ArrayList<Event> events) {
                         if (events.size() > 0) {
                             if (events.get(0).getGPlusEventLink() != null) {
 
@@ -60,11 +58,6 @@ public class GdgDashClockExtension extends DashClockExtension {
                             publishUpdate(new ExtensionData()
                                     .visible(false));
                         }
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                        Timber.e(t, "Error updating Widget");
                     }
                 });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/appwidget/GdgDashClockExtension.java
+++ b/app/src/main/java/org/gdg/frisbee/android/appwidget/GdgDashClockExtension.java
@@ -16,7 +16,7 @@ import org.joda.time.format.DateTimeFormat;
 import java.util.ArrayList;
 
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 import timber.log.Timber;
 
 public class GdgDashClockExtension extends DashClockExtension {
@@ -33,10 +33,11 @@ public class GdgDashClockExtension extends DashClockExtension {
         App.getInstance().getGroupDirectory().getChapterEventList(
                 (int) (new DateTime().getMillis() / 1000),
                 (int) (new DateTime().plusMonths(1).getMillis() / 1000),
-                homeGdg,
-                new Callback<ArrayList<Event>>() {
+                homeGdg)
+                .enqueue(new Callback<ArrayList<Event>>() {
                     @Override
-                    public void success(ArrayList<Event> events, retrofit.client.Response response) {
+                    public void onResponse(Response<ArrayList<Event>> response) {
+                        ArrayList<Event> events = response.body();
                         if (events.size() > 0) {
                             if (events.get(0).getGPlusEventLink() != null) {
 
@@ -62,8 +63,8 @@ public class GdgDashClockExtension extends DashClockExtension {
                     }
 
                     @Override
-                    public void failure(RetrofitError error) {
-                        Timber.e(error, "Error updating Widget");
+                    public void onFailure(Throwable t) {
+                        Timber.e(t, "Error updating Widget");
                     }
                 });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/appwidget/GdgDashClockExtension.java
+++ b/app/src/main/java/org/gdg/frisbee/android/appwidget/GdgDashClockExtension.java
@@ -35,7 +35,7 @@ public class GdgDashClockExtension extends DashClockExtension {
                 homeGdg)
                 .enqueue(new Callback<ArrayList<Event>>() {
                     @Override
-                    public void onSuccessResponse(ArrayList<Event> events) {
+                    public void success(ArrayList<Event> events) {
                         if (events.size() > 0) {
                             if (events.get(0).getGPlusEventLink() != null) {
 

--- a/app/src/main/java/org/gdg/frisbee/android/appwidget/UpcomingEventWidgetProvider.java
+++ b/app/src/main/java/org/gdg/frisbee/android/appwidget/UpcomingEventWidgetProvider.java
@@ -29,6 +29,7 @@ import android.widget.RemoteViews;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Chapter;
 import org.gdg.frisbee.android.api.model.Directory;
 import org.gdg.frisbee.android.api.model.Event;
@@ -42,8 +43,6 @@ import org.joda.time.format.DateTimeFormat;
 
 import java.util.ArrayList;
 
-import retrofit.Callback;
-import retrofit.Response;
 import timber.log.Timber;
 
 public class UpcomingEventWidgetProvider extends AppWidgetProvider {
@@ -123,10 +122,8 @@ public class UpcomingEventWidgetProvider extends AppWidgetProvider {
                             homeGdg.getGplusId())
                     .enqueue(new Callback<ArrayList<Event>>() {
                         @Override
-                        public void onResponse(Response<ArrayList<Event>> response) {
+                        public void onSuccessResponse(ArrayList<Event> events) {
                             Timber.d("Got events");
-
-                            ArrayList<Event> events = response.body();
                             if (events.size() > 0) {
                                 Event firstEvent = events.get(0);
                                 views.setTextViewText(R.id.title, firstEvent.getTitle());
@@ -147,10 +144,12 @@ public class UpcomingEventWidgetProvider extends AppWidgetProvider {
                         }
 
                         @Override
-                        public void onFailure(Throwable t) {
+                        public void onFailure(Throwable t, int errorMessage) {
 
-                            Timber.e(t, "Error updating Widget");
-                            showErrorChild(views, R.string.loading_data_failed, UpdateService.this);
+                            showErrorChild(views,
+                                    errorMessage == R.string.offline_alert
+                                            ? errorMessage : R.string.loading_data_failed,
+                                    UpdateService.this);
                             manager.updateAppWidget(thisWidget, views);
                         }
                     });

--- a/app/src/main/java/org/gdg/frisbee/android/appwidget/UpcomingEventWidgetProvider.java
+++ b/app/src/main/java/org/gdg/frisbee/android/appwidget/UpcomingEventWidgetProvider.java
@@ -144,12 +144,14 @@ public class UpcomingEventWidgetProvider extends AppWidgetProvider {
                         }
 
                         @Override
-                        public void failure(Throwable t, int errorMessage) {
+                        public void failure(Throwable error) {
+                            showErrorChild(views, R.string.loading_data_failed, UpdateService.this);
+                            manager.updateAppWidget(thisWidget, views);
+                        }
 
-                            showErrorChild(views,
-                                    errorMessage == R.string.offline_alert
-                                            ? errorMessage : R.string.loading_data_failed,
-                                    UpdateService.this);
+                        @Override
+                        public void networkFailure(Throwable error) {
+                            showErrorChild(views, R.string.offline_alert, UpdateService.this);
                             manager.updateAppWidget(thisWidget, views);
                         }
                     });

--- a/app/src/main/java/org/gdg/frisbee/android/appwidget/UpcomingEventWidgetProvider.java
+++ b/app/src/main/java/org/gdg/frisbee/android/appwidget/UpcomingEventWidgetProvider.java
@@ -122,7 +122,7 @@ public class UpcomingEventWidgetProvider extends AppWidgetProvider {
                             homeGdg.getGplusId())
                     .enqueue(new Callback<ArrayList<Event>>() {
                         @Override
-                        public void onSuccessResponse(ArrayList<Event> events) {
+                        public void success(ArrayList<Event> events) {
                             Timber.d("Got events");
                             if (events.size() > 0) {
                                 Event firstEvent = events.get(0);
@@ -144,7 +144,7 @@ public class UpcomingEventWidgetProvider extends AppWidgetProvider {
                         }
 
                         @Override
-                        public void onFailure(Throwable t, int errorMessage) {
+                        public void failure(Throwable t, int errorMessage) {
 
                             showErrorChild(views,
                                     errorMessage == R.string.offline_alert

--- a/app/src/main/java/org/gdg/frisbee/android/arrow/ArrowTaggedActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/arrow/ArrowTaggedActivity.java
@@ -117,7 +117,7 @@ public class ArrowTaggedActivity extends GdgActivity {
 
                         App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
                             @Override
-                            public void onSuccessResponse(Directory directory) {
+                            public void success(Directory directory) {
                                 loadChapterOrganizers(directory);
                             }
                         });

--- a/app/src/main/java/org/gdg/frisbee/android/arrow/ArrowTaggedActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/arrow/ArrowTaggedActivity.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 
 import butterknife.Bind;
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 import timber.log.Timber;
 
 public class ArrowTaggedActivity extends GdgActivity {
@@ -116,20 +116,17 @@ public class ArrowTaggedActivity extends GdgActivity {
                             }
                         }
 
-                        App.getInstance().getGdgXHub().getDirectory(
-                                new Callback<Directory>() {
+                        App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
+                            @Override
+                            public void onResponse(Response<Directory> response) {
+                                loadChapterOrganizers(response.body());
+                            }
 
-                                    @Override
-                                    public void success(final Directory directory, final retrofit.client.Response response) {
-                                        loadChapterOrganizers(directory);
-                                    }
-
-                                    @Override
-                                    public void failure(final RetrofitError error) {
-                                        Timber.e(error, "Error");
-                                    }
-                                }
-                        );
+                            @Override
+                            public void onFailure(Throwable t) {
+                                Timber.e(t, "Error");
+                            }
+                        });
                     }
                 });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/arrow/ArrowTaggedActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/arrow/ArrowTaggedActivity.java
@@ -32,6 +32,7 @@ import com.google.android.gms.plus.Plus;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Chapter;
 import org.gdg.frisbee.android.api.model.Directory;
 import org.gdg.frisbee.android.app.App;
@@ -42,8 +43,6 @@ import org.gdg.frisbee.android.view.DividerItemDecoration;
 import java.io.IOException;
 
 import butterknife.Bind;
-import retrofit.Callback;
-import retrofit.Response;
 import timber.log.Timber;
 
 public class ArrowTaggedActivity extends GdgActivity {
@@ -118,13 +117,8 @@ public class ArrowTaggedActivity extends GdgActivity {
 
                         App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
                             @Override
-                            public void onResponse(Response<Directory> response) {
-                                loadChapterOrganizers(response.body());
-                            }
-
-                            @Override
-                            public void onFailure(Throwable t) {
-                                Timber.e(t, "Error");
+                            public void onSuccessResponse(Directory directory) {
+                                loadChapterOrganizers(directory);
                             }
                         });
                     }

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -188,9 +188,7 @@ public class InfoFragment extends BaseFragment {
 
                 @Override
                 public void onNotFound(String key) {
-                    Snackbar snackbar = Snackbar.make(getView(), R.string.offline_alert,
-                            Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.alert(snackbar).show();
+                    showError(R.string.offline_alert);
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
@@ -50,6 +50,7 @@ import org.gdg.frisbee.android.BuildConfig;
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.activity.AppInviteDeepLinkActivity;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Chapter;
 import org.gdg.frisbee.android.api.model.Directory;
 import org.gdg.frisbee.android.app.App;

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
@@ -266,9 +266,7 @@ public class MainActivity extends GdgNavDrawerActivity {
     private void fetchChapters() {
         App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
             @Override
-            public void onSuccessResponse(Directory directory) {
-                ArrayList<Chapter> chapters = directory.getGroups();
-                initChapters(chapters);
+            public void success(final Directory directory) {
 
                 App.getInstance().getModelCache().putAsync(
                         Const.CACHE_KEY_CHAPTER_LIST_HUB,
@@ -277,12 +275,14 @@ public class MainActivity extends GdgNavDrawerActivity {
                         new ModelCache.CachePutListener() {
                             @Override
                             public void onPutIntoCache() {
+                                ArrayList<Chapter> chapters = directory.getGroups();
+                                initChapters(chapters);
                             }
                         });
             }
 
             @Override
-            public void onFailure(Throwable t, int errorMessage) {
+            public void failure(Throwable t, int errorMessage) {
                 try {
                     if (errorMessage != R.string.offline_alert) {
                         errorMessage = R.string.fetch_chapters_failed;

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
@@ -24,7 +24,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -37,7 +36,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
-import android.widget.FrameLayout;
 import android.widget.Spinner;
 
 import com.google.android.gms.appindexing.Action;
@@ -62,7 +60,6 @@ import org.gdg.frisbee.android.eventseries.GdgEventListFragment;
 import org.gdg.frisbee.android.onboarding.FirstStartActivity;
 import org.gdg.frisbee.android.utils.PrefUtils;
 import org.gdg.frisbee.android.utils.Utils;
-import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
@@ -94,8 +91,6 @@ public class MainActivity extends GdgNavDrawerActivity {
     ViewPager mViewPager;
     @Bind(R.id.tabs)
     TabLayout mTabLayout;
-    @Bind(R.id.content_frame)
-    FrameLayout mContentFrameLayout;
 
     private Handler mHandler = new Handler();
     private ChapterAdapter mChapterAdapter;
@@ -176,12 +171,7 @@ public class MainActivity extends GdgNavDrawerActivity {
                             if (Utils.isOnline(MainActivity.this)) {
                                 fetchChapters();
                             } else {
-                                Snackbar snackbar = Snackbar.make(
-                                        mContentFrameLayout,
-                                        getString(R.string.offline_alert),
-                                        Snackbar.LENGTH_SHORT
-                                );
-                                ColoredSnackBar.alert(snackbar).show();
+                                showError(R.string.offline_alert);
                             }
                         }
                     }
@@ -283,16 +273,13 @@ public class MainActivity extends GdgNavDrawerActivity {
             }
 
             @Override
-            public void failure(Throwable t, int errorMessage) {
-                try {
-                    if (errorMessage != R.string.offline_alert) {
-                        errorMessage = R.string.fetch_chapters_failed;
-                    }
-                    Snackbar snackbar = Snackbar.make(mContentFrameLayout, errorMessage,
-                            Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.alert(snackbar).show();
-                } catch (IllegalStateException ignored) {
-                }
+            public void failure(Throwable error) {
+                showError(R.string.fetch_chapters_failed);
+            }
+
+            @Override
+            public void networkFailure(Throwable error) {
+                showError(R.string.offline_alert);
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/MainActivity.java
@@ -69,9 +69,6 @@ import java.util.Collections;
 import java.util.List;
 
 import butterknife.Bind;
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.http.HEAD;
 import timber.log.Timber;
 
 public class MainActivity extends GdgNavDrawerActivity {
@@ -269,9 +266,7 @@ public class MainActivity extends GdgNavDrawerActivity {
     private void fetchChapters() {
         App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
             @Override
-            public void onResponse(Response<Directory> response) {
-                final Directory directory = response.body();
-
+            public void onSuccessResponse(Directory directory) {
                 ArrayList<Chapter> chapters = directory.getGroups();
                 initChapters(chapters);
 
@@ -287,14 +282,16 @@ public class MainActivity extends GdgNavDrawerActivity {
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Throwable t, int errorMessage) {
                 try {
-                    Snackbar snackbar = Snackbar.make(mContentFrameLayout, getString(R.string.fetch_chapters_failed),
+                    if (errorMessage != R.string.offline_alert) {
+                        errorMessage = R.string.fetch_chapters_failed;
+                    }
+                    Snackbar snackbar = Snackbar.make(mContentFrameLayout, errorMessage,
                             Snackbar.LENGTH_SHORT);
                     ColoredSnackBar.alert(snackbar).show();
                 } catch (IllegalStateException ignored) {
                 }
-                Timber.e(t, "Couldn't fetch chapter list");
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/NewsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/NewsFragment.java
@@ -129,11 +129,7 @@ public class NewsFragment extends SwipeRefreshRecyclerViewFragment
 
                 @Override
                 public void onNotFound(String key) {
-                    if (isAdded()) {
-                        Snackbar snackbar = Snackbar.make(getView(), R.string.offline_alert,
-                                Snackbar.LENGTH_SHORT);
-                        ColoredSnackBar.alert(snackbar).show();
-                    }
+                    showError(R.string.offline_alert);
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/common/BaseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/BaseFragment.java
@@ -2,12 +2,16 @@ package org.gdg.frisbee.android.common;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
+import android.widget.Toast;
 
 import com.squareup.leakcanary.RefWatcher;
 
 import org.gdg.frisbee.android.BuildConfig;
 import org.gdg.frisbee.android.app.App;
+import org.gdg.frisbee.android.view.ColoredSnackBar;
 
 import butterknife.ButterKnife;
 import timber.log.Timber;
@@ -38,5 +42,17 @@ public abstract class BaseFragment extends Fragment {
             Timber.d("Context is not valid");
         }
         return isContextValid;
+    }
+
+    protected void showError(@StringRes final int errorStringRes) {
+        if (isContextValid()) {
+            if (getView() != null) {
+                Snackbar snackbar = Snackbar.make(getView(), errorStringRes,
+                        Snackbar.LENGTH_SHORT);
+                ColoredSnackBar.alert(snackbar).show();
+            } else {
+                Toast.makeText(getActivity(), errorStringRes, Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -25,7 +25,12 @@ import android.content.IntentSender;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
 import android.support.v7.widget.Toolbar;
+import android.widget.FrameLayout;
+import android.widget.Toast;
 
 import com.google.android.gms.appindexing.Action;
 import com.google.android.gms.appindexing.AppIndex;
@@ -45,14 +50,20 @@ import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.utils.PrefUtils;
 import org.gdg.frisbee.android.utils.RecentTasksStyler;
 import org.gdg.frisbee.android.utils.Utils;
+import org.gdg.frisbee.android.view.ColoredSnackBar;
 
 import java.util.List;
 
+import butterknife.Bind;
 import butterknife.ButterKnife;
 import timber.log.Timber;
 
 public abstract class GdgActivity extends TrackableActivity implements
         GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
+
+    @Nullable
+    @Bind(R.id.content_frame)
+    FrameLayout mContentLayout;
 
     private static final int STATE_DEFAULT = 0;
     private static final int STATE_SIGN_IN = 1;
@@ -253,6 +264,18 @@ public abstract class GdgActivity extends TrackableActivity implements
             Timber.d("Context is not valid");
         }
         return isContextValid;
+    }
+
+    protected void showError(@StringRes final int errorStringRes) {
+        if (isContextValid()) {
+            if (mContentLayout != null) {
+                Snackbar snackbar = Snackbar.make(mContentLayout, errorStringRes,
+                        Snackbar.LENGTH_SHORT);
+                ColoredSnackBar.alert(snackbar).show();
+            } else {
+                Toast.makeText(this, errorStringRes, Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 
     private boolean isLastActivityOnStack() {

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
@@ -23,7 +23,6 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.customtabs.CustomTabsIntent;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.ShareActionProvider;
@@ -54,16 +53,16 @@ import org.gdg.frisbee.android.api.model.Directory;
 import org.gdg.frisbee.android.api.model.EventFullDetails;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
+import org.gdg.frisbee.android.common.BaseFragment;
 import org.gdg.frisbee.android.common.GdgActivity;
 import org.gdg.frisbee.android.utils.Utils;
-import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
 
-public class EventOverviewFragment extends Fragment {
+public class EventOverviewFragment extends BaseFragment {
 
     @Bind(R.id.title)
     TextView mTitle;
@@ -116,13 +115,13 @@ public class EventOverviewFragment extends Fragment {
             }
 
             @Override
-            public void failure(Throwable t, int errorMessage) {
+            public void failure(Throwable error) {
+                showError(R.string.server_error);
+            }
 
-                if (isAdded()) {
-                    Snackbar snackbar = Snackbar.make(getView(), errorMessage,
-                            Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.alert(snackbar).show();
-                }
+            @Override
+            public void networkFailure(Throwable error) {
+                showError(R.string.offline_alert);
             }
         });
     }
@@ -192,21 +191,17 @@ public class EventOverviewFragment extends Fragment {
                         }
 
                         @Override
-                        public void failure(Throwable t, int errorMessage) {
-                            if (isAdded()) {
-                                if (errorMessage != R.string.offline_alert) {
-                                    errorMessage = R.string.fetch_chapters_failed;
-                                }
-                                Snackbar snackbar = Snackbar.make(getView(), errorMessage,
-                                        Snackbar.LENGTH_SHORT);
-                                ColoredSnackBar.alert(snackbar).show();
-                            }
+                        public void failure(Throwable error) {
+                            showError(R.string.fetch_chapters_failed);
+                        }
+
+                        @Override
+                        public void networkFailure(Throwable error) {
+                            showError(R.string.offline_alert);
                         }
                     });
                 } else {
-                    Snackbar snackbar = Snackbar.make(getView(), R.string.offline_alert,
-                            Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.alert(snackbar).show();
+                    showError(R.string.offline_alert);
                 }
             }
         });

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
@@ -48,6 +48,7 @@ import com.tasomaniac.android.widget.DelayedProgressBar;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Chapter;
 import org.gdg.frisbee.android.api.model.Directory;
 import org.gdg.frisbee.android.api.model.EventFullDetails;
@@ -61,9 +62,6 @@ import org.joda.time.format.DateTimeFormatter;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
-import retrofit.Callback;
-import retrofit.Response;
-import timber.log.Timber;
 
 public class EventOverviewFragment extends Fragment {
 
@@ -113,19 +111,18 @@ public class EventOverviewFragment extends Fragment {
         final String eventId = getArguments().getString(Const.EXTRA_EVENT_ID);
         App.getInstance().getGdgXHub().getEventDetail(eventId).enqueue(new Callback<EventFullDetails>() {
             @Override
-            public void onResponse(Response<EventFullDetails> response) {
-                EventOverviewFragment.this.onResponse(response.body());
+            public void onSuccessResponse(EventFullDetails response) {
+                onSuccess(response);
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Throwable t, int errorMessage) {
 
                 if (isAdded()) {
-                    Snackbar snackbar = Snackbar.make(getView(), R.string.server_error,
+                    Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                             Snackbar.LENGTH_SHORT);
                     ColoredSnackBar.alert(snackbar).show();
                 }
-                Timber.d(t, "error while retrieving event %s", eventId);
             }
         });
     }
@@ -165,7 +162,7 @@ public class EventOverviewFragment extends Fragment {
         return fmt.print(eventFullDetails.getStart());
     }
 
-    private void onResponse(final EventFullDetails eventFullDetails) {
+    private void onSuccess(final EventFullDetails eventFullDetails) {
         if (getActivity() == null) {
             return;
         }
@@ -189,19 +186,21 @@ public class EventOverviewFragment extends Fragment {
                 if (Utils.isOnline(getActivity())) {
                     App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
                         @Override
-                        public void onResponse(Response<Directory> response) {
-                            mDirectory = response.body();
+                        public void onSuccessResponse(Directory directory) {
+                            mDirectory = directory;
                             updateGroupDetails(mDirectory.getGroupById(eventFullDetails.getChapter()));
                         }
 
                         @Override
-                        public void onFailure(Throwable t) {
+                        public void onFailure(Throwable t, int errorMessage) {
                             if (isAdded()) {
-                                Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_chapters_failed,
+                                if (errorMessage != R.string.offline_alert) {
+                                    errorMessage = R.string.fetch_chapters_failed;
+                                }
+                                Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                                         Snackbar.LENGTH_SHORT);
                                 ColoredSnackBar.alert(snackbar).show();
                             }
-                            Timber.e(t, "Could'nt fetch chapter list");
                         }
                     });
                 } else {

--- a/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/event/EventOverviewFragment.java
@@ -111,12 +111,12 @@ public class EventOverviewFragment extends Fragment {
         final String eventId = getArguments().getString(Const.EXTRA_EVENT_ID);
         App.getInstance().getGdgXHub().getEventDetail(eventId).enqueue(new Callback<EventFullDetails>() {
             @Override
-            public void onSuccessResponse(EventFullDetails response) {
-                onSuccess(response);
+            public void success(EventFullDetails eventFullDetails) {
+                onSuccess(eventFullDetails);
             }
 
             @Override
-            public void onFailure(Throwable t, int errorMessage) {
+            public void failure(Throwable t, int errorMessage) {
 
                 if (isAdded()) {
                     Snackbar snackbar = Snackbar.make(getView(), errorMessage,
@@ -186,13 +186,13 @@ public class EventOverviewFragment extends Fragment {
                 if (Utils.isOnline(getActivity())) {
                     App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
                         @Override
-                        public void onSuccessResponse(Directory directory) {
+                        public void success(Directory directory) {
                             mDirectory = directory;
                             updateGroupDetails(mDirectory.getGroupById(eventFullDetails.getChapter()));
                         }
 
                         @Override
-                        public void onFailure(Throwable t, int errorMessage) {
+                        public void failure(Throwable t, int errorMessage) {
                             if (isAdded()) {
                                 if (errorMessage != R.string.offline_alert) {
                                     errorMessage = R.string.fetch_chapters_failed;

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
@@ -20,7 +20,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.StringRes;
-import android.support.design.widget.Snackbar;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -34,7 +33,6 @@ import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.api.model.SimpleEvent;
 import org.gdg.frisbee.android.common.GdgListFragment;
 import org.gdg.frisbee.android.event.EventActivity;
-import org.gdg.frisbee.android.view.ColoredSnackBar;
 
 import java.util.ArrayList;
 
@@ -48,15 +46,7 @@ public abstract class EventListFragment extends GdgListFragment {
     
     protected void onError(@StringRes int errorMessage) {
         setIsLoading(false);
-        if (isAdded()) {
-            if (errorMessage != R.string.offline_alert) {
-                errorMessage = R.string.fetch_events_failed;
-            }
-            Snackbar snackbar = Snackbar.make(getView(), errorMessage,
-                    Snackbar.LENGTH_SHORT);
-            ColoredSnackBar.alert(snackbar).show();
-        }
-
+        showError(errorMessage);
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/EventListFragment.java
@@ -19,6 +19,7 @@ package org.gdg.frisbee.android.eventseries;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -45,11 +46,13 @@ public abstract class EventListFragment extends GdgListFragment {
 
     protected ArrayList<SimpleEvent> mEvents;
     
-    protected void onError(Throwable e) {
+    protected void onError(@StringRes int errorMessage) {
         setIsLoading(false);
-        e.printStackTrace();
         if (isAdded()) {
-            Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_events_failed,
+            if (errorMessage != R.string.offline_alert) {
+                errorMessage = R.string.fetch_events_failed;
+            }
+            Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                     Snackbar.LENGTH_SHORT);
             ColoredSnackBar.alert(snackbar).show();
         }
@@ -149,5 +152,15 @@ public abstract class EventListFragment extends GdgListFragment {
         View v = inflater.inflate(R.layout.fragment_events, container, false);
         ButterKnife.bind(this, v);
         return v;
+    }
+
+    protected boolean checkValidCache(Object item) {
+        if (item instanceof ArrayList) {
+            ArrayList<?> result = (ArrayList) item;
+            if (result.size() > 0) {
+                return result.get(0) instanceof SimpleEvent;
+            }
+        }
+        return false;
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 
 public class GdgEventListFragment extends EventListFragment {
 
@@ -49,10 +49,10 @@ public class GdgEventListFragment extends EventListFragment {
 
 
         if (Utils.isOnline(getActivity())) {
-            App.getInstance().getGroupDirectory().getChapterEventList(mStart, mEnd, plusId, new Callback<ArrayList<Event>>() {
+            App.getInstance().getGroupDirectory().getChapterEventList(mStart, mEnd, plusId).enqueue(new Callback<ArrayList<Event>>() {
                 @Override
-                public void success(ArrayList<Event> events, retrofit.client.Response response) {
-                    splitEventsAndAddToAdapter(events);
+                public void onResponse(Response<ArrayList<Event>> response) {
+                    splitEventsAndAddToAdapter(response.body());
                     App.getInstance().getModelCache().putAsync(cacheKey, mEvents, DateTime.now().plusHours(2), new ModelCache.CachePutListener() {
                         @Override
                         public void onPutIntoCache() {
@@ -63,8 +63,8 @@ public class GdgEventListFragment extends EventListFragment {
                 }
 
                 @Override
-                public void failure(RetrofitError error) {
-                    onError(error);
+                public void onFailure(Throwable t) {
+                    onError(t);
                 }
             });
         } else {

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
@@ -61,8 +61,13 @@ public class GdgEventListFragment extends EventListFragment {
                 }
 
                 @Override
-                public void failure(Throwable t, int errorMessage) {
-                    onError(errorMessage);
+                public void failure(Throwable error) {
+                    onError(R.string.fetch_events_failed);
+                }
+
+                @Override
+                public void networkFailure(Throwable error) {
+                    onError(R.string.offline_alert);
                 }
             });
         } else {
@@ -90,11 +95,7 @@ public class GdgEventListFragment extends EventListFragment {
 
                 private void onNotFound() {
                     setIsLoading(false);
-                    if (isAdded()) {
-                        Snackbar snackbar = Snackbar.make(getView(), R.string.offline_alert,
-                                Snackbar.LENGTH_SHORT);
-                        ColoredSnackBar.alert(snackbar).show();
-                    }
+                    showError(R.string.offline_alert);
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/GdgEventListFragment.java
@@ -49,7 +49,7 @@ public class GdgEventListFragment extends EventListFragment {
         if (Utils.isOnline(getActivity())) {
             App.getInstance().getGroupDirectory().getChapterEventList(mStart, mEnd, plusId).enqueue(new Callback<ArrayList<Event>>() {
                 @Override
-                public void onSuccessResponse(ArrayList<Event> events) {
+                public void success(ArrayList<Event> events) {
                     splitEventsAndAddToAdapter(events);
                     App.getInstance().getModelCache().putAsync(cacheKey, mEvents, DateTime.now().plusHours(2), new ModelCache.CachePutListener() {
                         @Override
@@ -61,7 +61,7 @@ public class GdgEventListFragment extends EventListFragment {
                 }
 
                 @Override
-                public void onFailure(Throwable t, int errorMessage) {
+                public void failure(Throwable t, int errorMessage) {
                     onError(errorMessage);
                 }
             });

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
@@ -42,7 +42,7 @@ import java.util.Comparator;
 
 import butterknife.ButterKnife;
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 
 public class TaggedEventSeriesFragment extends EventListFragment {
 
@@ -113,10 +113,9 @@ public class TaggedEventSeriesFragment extends EventListFragment {
         setIsLoading(true);
 
         Callback<PagedList<TaggedEvent>> listener = new Callback<PagedList<TaggedEvent>>() {
-
             @Override
-            public void success(final PagedList<TaggedEvent> taggedEventPagedList, final retrofit.client.Response response) {
-                mEvents.addAll(taggedEventPagedList.getItems());
+            public void onResponse(Response<PagedList<TaggedEvent>> response) {
+                mEvents.addAll(response.body().getItems());
                 App.getInstance().getModelCache().putAsync(mCacheKey,
                         mEvents,
                         DateTime.now().plusHours(2),
@@ -131,14 +130,14 @@ public class TaggedEventSeriesFragment extends EventListFragment {
             }
 
             @Override
-            public void failure(final RetrofitError error) {
-                onError(error);
+            public void onFailure(Throwable t) {
+                onError(t);
             }
         };
 
         if (Utils.isOnline(getActivity())) {
             App.getInstance().getGdgXHub()
-                    .getTaggedEventUpcomingList(mTaggedEventSeries.getTag(), DateTime.now(), listener);
+                    .getTaggedEventUpcomingList(mTaggedEventSeries.getTag(), DateTime.now()).enqueue(listener);
         } else {
             App.getInstance().getModelCache().getAsync(mCacheKey, false, new ModelCache.CacheListener() {
                 @Override

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
@@ -113,8 +113,8 @@ public class TaggedEventSeriesFragment extends EventListFragment {
 
         Callback<PagedList<TaggedEvent>> listener = new Callback<PagedList<TaggedEvent>>() {
             @Override
-            public void onSuccessResponse(PagedList<TaggedEvent> response) {
-                mEvents.addAll(response.getItems());
+            public void success(final PagedList<TaggedEvent> taggedEventPagedList) {
+                mEvents.addAll(taggedEventPagedList.getItems());
                 App.getInstance().getModelCache().putAsync(mCacheKey,
                         mEvents,
                         DateTime.now().plusHours(2),
@@ -129,7 +129,7 @@ public class TaggedEventSeriesFragment extends EventListFragment {
             }
 
             @Override
-            public void onFailure(Throwable t, int errorMessage) {
+            public void failure(Throwable t, int errorMessage) {
                 onError(errorMessage);
             }
         };

--- a/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/eventseries/TaggedEventSeriesFragment.java
@@ -129,8 +129,13 @@ public class TaggedEventSeriesFragment extends EventListFragment {
             }
 
             @Override
-            public void failure(Throwable t, int errorMessage) {
-                onError(errorMessage);
+            public void failure(Throwable error) {
+                onError(R.string.fetch_events_failed);
+            }
+
+            @Override
+            public void networkFailure(Throwable error) {
+                onError(R.string.offline_alert);
             }
         };
 
@@ -164,11 +169,7 @@ public class TaggedEventSeriesFragment extends EventListFragment {
 
                 private void onNotFound() {
                     setIsLoading(false);
-                    if (isAdded()) {
-                        Snackbar snackbar = Snackbar.make(getView(), R.string.offline_alert,
-                                Snackbar.LENGTH_SHORT);
-                        ColoredSnackBar.alert(snackbar).show();
-                    }
+                    showError(R.string.offline_alert);
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -57,8 +57,7 @@ import org.gdg.frisbee.android.utils.PrefUtils;
 import java.io.IOException;
 
 import retrofit.Callback;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
+import retrofit.Response;
 import timber.log.Timber;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -101,36 +100,39 @@ public class SettingsFragment extends PreferenceFragment {
                             }
 
                             GdgXHub client = App.getInstance().getGdgXHub();
-                            String token = GoogleAuthUtil.getToken(getActivity(), 
-                                    Plus.AccountApi.getAccountName(mGoogleApiClient), 
+                            String token = GoogleAuthUtil.getToken(getActivity(),
+                                    Plus.AccountApi.getAccountName(mGoogleApiClient),
                                     "oauth2: " + Scopes.PLUS_LOGIN);
 
                             if (!enableGcm) {
-                                client.unregisterGcm("Bearer " + token, new GcmRegistrationRequest(PrefUtils.getRegistrationId(getActivity())),
-                                        new Callback<GcmRegistrationResponse>() {
+                                client.unregisterGcm("Bearer " + token, new GcmRegistrationRequest(PrefUtils.getRegistrationId(getActivity())))
+                                        .enqueue(new Callback<GcmRegistrationResponse>() {
                                             @Override
-                                            public void success(GcmRegistrationResponse gcmRegistrationResponse, retrofit.client.Response response) {
+                                            public void onResponse(Response<GcmRegistrationResponse> response) {
                                                 PrefUtils.setGcmSettings(getActivity(), false, null, null);
                                             }
 
                                             @Override
-                                            public void failure(RetrofitError error) {
-                                                Timber.e(error, "Fail");
+                                            public void onFailure(Throwable t) {
+                                                Timber.e(t, "Fail");
                                             }
                                         });
                             } else {
                                 final String regId = mGcm.register(BuildConfig.GCM_SENDER_ID);
 
-                                client.registerGcm("Bearer " + token, new GcmRegistrationRequest(regId),
-                                        new Callback<GcmRegistrationResponse>() {
+                                client.registerGcm("Bearer " + token, new GcmRegistrationRequest(regId))
+                                        .enqueue(new Callback<GcmRegistrationResponse>() {
                                             @Override
-                                            public void success(GcmRegistrationResponse gcmRegistrationResponse, retrofit.client.Response response) {
-                                                PrefUtils.setGcmSettings(getActivity(), true, regId, gcmRegistrationResponse.getNotificationKey());
+                                            public void onResponse(Response<GcmRegistrationResponse> response) {
+                                                PrefUtils.setGcmSettings(getActivity(),
+                                                        true,
+                                                        regId,
+                                                        response.body().getNotificationKey());
                                             }
 
                                             @Override
-                                            public void failure(RetrofitError error) {
-                                                Timber.e(error, "Fail");
+                                            public void onFailure(Throwable t) {
+                                                Timber.e(t, "Fail");
                                             }
                                         });
 
@@ -290,15 +292,16 @@ public class SettingsFragment extends PreferenceFragment {
                             "oauth2: " + Scopes.PLUS_LOGIN);
 
                     App.getInstance().getGdgXHub().setHomeGdg("Bearer " + token,
-                            new HomeGdgRequest(homeGdg),
-                            new Callback<Void>() {
+                            new HomeGdgRequest(homeGdg))
+                            .enqueue(new Callback<Void>() {
                                 @Override
-                                public void success(Void aVoid, Response response) {
+                                public void onResponse(Response<Void> response) {
+
                                 }
 
                                 @Override
-                                public void failure(RetrofitError error) {
-                                    Timber.e(error, "Setting Home failed.");
+                                public void onFailure(Throwable t) {
+                                    Timber.e(t, "Setting Home failed.");
                                 }
                             });
                 } catch (IOException | GoogleAuthException e) {

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -42,6 +42,7 @@ import com.google.android.gms.plus.Plus;
 import org.gdg.frisbee.android.BuildConfig;
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.GdgXHub;
 import org.gdg.frisbee.android.api.model.Chapter;
 import org.gdg.frisbee.android.api.model.Directory;
@@ -56,8 +57,6 @@ import org.gdg.frisbee.android.utils.PrefUtils;
 
 import java.io.IOException;
 
-import retrofit.Callback;
-import retrofit.Response;
 import timber.log.Timber;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -108,13 +107,8 @@ public class SettingsFragment extends PreferenceFragment {
                                 client.unregisterGcm("Bearer " + token, new GcmRegistrationRequest(PrefUtils.getRegistrationId(getActivity())))
                                         .enqueue(new Callback<GcmRegistrationResponse>() {
                                             @Override
-                                            public void onResponse(Response<GcmRegistrationResponse> response) {
+                                            public void onSuccessResponse(GcmRegistrationResponse response) {
                                                 PrefUtils.setGcmSettings(getActivity(), false, null, null);
-                                            }
-
-                                            @Override
-                                            public void onFailure(Throwable t) {
-                                                Timber.e(t, "Fail");
                                             }
                                         });
                             } else {
@@ -123,16 +117,11 @@ public class SettingsFragment extends PreferenceFragment {
                                 client.registerGcm("Bearer " + token, new GcmRegistrationRequest(regId))
                                         .enqueue(new Callback<GcmRegistrationResponse>() {
                                             @Override
-                                            public void onResponse(Response<GcmRegistrationResponse> response) {
+                                            public void onSuccessResponse(GcmRegistrationResponse response) {
                                                 PrefUtils.setGcmSettings(getActivity(),
                                                         true,
                                                         regId,
-                                                        response.body().getNotificationKey());
-                                            }
-
-                                            @Override
-                                            public void onFailure(Throwable t) {
-                                                Timber.e(t, "Fail");
+                                                        response.getNotificationKey());
                                             }
                                         });
 
@@ -295,13 +284,7 @@ public class SettingsFragment extends PreferenceFragment {
                             new HomeGdgRequest(homeGdg))
                             .enqueue(new Callback<Void>() {
                                 @Override
-                                public void onResponse(Response<Void> response) {
-
-                                }
-
-                                @Override
-                                public void onFailure(Throwable t) {
-                                    Timber.e(t, "Setting Home failed.");
+                                public void onSuccessResponse(Void response) {
                                 }
                             });
                 } catch (IOException | GoogleAuthException e) {

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -107,7 +107,7 @@ public class SettingsFragment extends PreferenceFragment {
                                 client.unregisterGcm("Bearer " + token, new GcmRegistrationRequest(PrefUtils.getRegistrationId(getActivity())))
                                         .enqueue(new Callback<GcmRegistrationResponse>() {
                                             @Override
-                                            public void onSuccessResponse(GcmRegistrationResponse response) {
+                                            public void success(GcmRegistrationResponse gcmRegistrationResponse) {
                                                 PrefUtils.setGcmSettings(getActivity(), false, null, null);
                                             }
                                         });
@@ -117,11 +117,8 @@ public class SettingsFragment extends PreferenceFragment {
                                 client.registerGcm("Bearer " + token, new GcmRegistrationRequest(regId))
                                         .enqueue(new Callback<GcmRegistrationResponse>() {
                                             @Override
-                                            public void onSuccessResponse(GcmRegistrationResponse response) {
-                                                PrefUtils.setGcmSettings(getActivity(),
-                                                        true,
-                                                        regId,
-                                                        response.getNotificationKey());
+                                            public void success(GcmRegistrationResponse gcmRegistrationResponse) {
+                                                PrefUtils.setGcmSettings(getActivity(), true, regId, gcmRegistrationResponse.getNotificationKey());
                                             }
                                         });
 
@@ -284,7 +281,7 @@ public class SettingsFragment extends PreferenceFragment {
                             new HomeGdgRequest(homeGdg))
                             .enqueue(new Callback<Void>() {
                                 @Override
-                                public void onSuccessResponse(Void response) {
+                                public void success(Void response) {
                                 }
                             });
                 } catch (IOException | GoogleAuthException e) {

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -279,11 +279,7 @@ public class SettingsFragment extends PreferenceFragment {
 
                     App.getInstance().getGdgXHub().setHomeGdg("Bearer " + token,
                             new HomeGdgRequest(homeGdg))
-                            .enqueue(new Callback<Void>() {
-                                @Override
-                                public void success(Void response) {
-                                }
-                            });
+                            .execute();
                 } catch (IOException | GoogleAuthException e) {
                     e.printStackTrace();
                 }

--- a/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
@@ -14,6 +14,7 @@ import android.widget.FrameLayout;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Gde;
 import org.gdg.frisbee.android.api.model.GdeList;
 import org.gdg.frisbee.android.app.App;
@@ -29,9 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import butterknife.Bind;
-import retrofit.Callback;
-import retrofit.Response;
-import timber.log.Timber;
 
 public class GdeActivity extends GdgNavDrawerActivity {
 
@@ -78,8 +76,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
 
         App.getInstance().getGdeDirectory().getDirectory().enqueue(new Callback<GdeList>() {
             @Override
-            public void onResponse(Response<GdeList> response) {
-                final GdeList directory = response.body();
+            public void onSuccessResponse(final GdeList directory) {
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_GDE_LIST,
                         directory,
                         DateTime.now().plusDays(4),
@@ -92,14 +89,16 @@ public class GdeActivity extends GdgNavDrawerActivity {
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Throwable t, int errorMessage) {
                 try {
-                    Snackbar snackbar = Snackbar.make(mContentLayout, R.string.fetch_gde_failed,
+                    if (errorMessage != R.string.offline_alert) {
+                        errorMessage = R.string.fetch_gde_failed;
+                    }
+                    Snackbar snackbar = Snackbar.make(mContentLayout, errorMessage,
                             Snackbar.LENGTH_SHORT);
                     ColoredSnackBar.alert(snackbar).show();
                 } catch (IllegalStateException ignored) {
                 }
-                Timber.e(t, "Could'nt fetch GDE list");
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 import butterknife.Bind;
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 import timber.log.Timber;
 
 public class GdeActivity extends GdgNavDrawerActivity {
@@ -76,9 +76,10 @@ public class GdeActivity extends GdgNavDrawerActivity {
     
     private void fetchGdeDirectory() {
 
-        App.getInstance().getGdeDirectory().getDirectory(new Callback<GdeList>() {
+        App.getInstance().getGdeDirectory().getDirectory().enqueue(new Callback<GdeList>() {
             @Override
-            public void success(final GdeList directory, retrofit.client.Response response) {
+            public void onResponse(Response<GdeList> response) {
+                final GdeList directory = response.body();
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_GDE_LIST,
                         directory,
                         DateTime.now().plusDays(4),
@@ -91,15 +92,14 @@ public class GdeActivity extends GdgNavDrawerActivity {
             }
 
             @Override
-            public void failure(RetrofitError error) {
-
+            public void onFailure(Throwable t) {
                 try {
                     Snackbar snackbar = Snackbar.make(mContentLayout, R.string.fetch_gde_failed,
                             Snackbar.LENGTH_SHORT);
                     ColoredSnackBar.alert(snackbar).show();
-                } catch (IllegalStateException exception) {
+                } catch (IllegalStateException ignored) {
                 }
-                Timber.e(error, "Could'nt fetch GDE list");
+                Timber.e(t, "Could'nt fetch GDE list");
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
@@ -2,7 +2,6 @@ package org.gdg.frisbee.android.gde;
 
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -10,7 +9,6 @@ import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.Toolbar;
 import android.util.SparseArray;
-import android.widget.FrameLayout;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
@@ -22,7 +20,6 @@ import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.common.GdgNavDrawerActivity;
 import org.gdg.frisbee.android.common.PlainLayoutFragment;
 import org.gdg.frisbee.android.utils.Utils;
-import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.DateTime;
 
 import java.lang.ref.WeakReference;
@@ -38,9 +35,6 @@ public class GdeActivity extends GdgNavDrawerActivity {
 
     @Bind(R.id.tabs)
     TabLayout mTabLayout;
-
-    @Bind(R.id.content_frame)
-    FrameLayout mContentLayout;
 
     private Handler mHandler = new Handler();
 
@@ -71,7 +65,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
             }
         });
     }
-    
+
     private void fetchGdeDirectory() {
 
         App.getInstance().getGdeDirectory().getDirectory().enqueue(new Callback<GdeList>() {
@@ -89,16 +83,13 @@ public class GdeActivity extends GdgNavDrawerActivity {
             }
 
             @Override
-            public void failure(Throwable t, int errorMessage) {
-                try {
-                    if (errorMessage != R.string.offline_alert) {
-                        errorMessage = R.string.fetch_gde_failed;
-                    }
-                    Snackbar snackbar = Snackbar.make(mContentLayout, errorMessage,
-                            Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.alert(snackbar).show();
-                } catch (IllegalStateException ignored) {
-                }
+            public void failure(Throwable error) {
+                showError(R.string.fetch_gde_failed);
+            }
+
+            @Override
+            public void networkFailure(Throwable error) {
+                showError(R.string.offline_alert);
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
@@ -76,7 +76,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
 
         App.getInstance().getGdeDirectory().getDirectory().enqueue(new Callback<GdeList>() {
             @Override
-            public void onSuccessResponse(final GdeList directory) {
+            public void success(final GdeList directory) {
                 App.getInstance().getModelCache().putAsync(Const.CACHE_KEY_GDE_LIST,
                         directory,
                         DateTime.now().plusDays(4),
@@ -89,7 +89,7 @@ public class GdeActivity extends GdgNavDrawerActivity {
             }
 
             @Override
-            public void onFailure(Throwable t, int errorMessage) {
+            public void failure(Throwable t, int errorMessage) {
                 try {
                     if (errorMessage != R.string.offline_alert) {
                         errorMessage = R.string.fetch_gde_failed;

--- a/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
@@ -113,7 +113,7 @@ public class FirstStartStep1Fragment extends BaseFragment {
 
         App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
             @Override
-            public void onSuccessResponse(Directory directory) {
+            public void success(Directory directory) {
 
                 if (isContextValid()) {
                     addChapters(directory.getGroups());
@@ -126,7 +126,7 @@ public class FirstStartStep1Fragment extends BaseFragment {
             }
 
             @Override
-            public void onFailure(Throwable t, int errorMessage) {
+            public void failure(Throwable t, int errorMessage) {
                 if (isContextValid()) {
                     if (errorMessage != R.string.offline_alert) {
                         errorMessage = R.string.fetch_chapters_failed;

--- a/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
@@ -17,12 +17,14 @@
 package org.gdg.frisbee.android.onboarding;
 
 import android.os.Bundle;
+import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.Spinner;
+import android.widget.Toast;
 import android.widget.ViewSwitcher;
 
 import org.gdg.frisbee.android.Const;
@@ -126,23 +128,34 @@ public class FirstStartStep1Fragment extends BaseFragment {
             }
 
             @Override
-            public void failure(Throwable t, int errorMessage) {
-                if (isContextValid()) {
-                    if (errorMessage != R.string.offline_alert) {
-                        errorMessage = R.string.fetch_chapters_failed;
-                    }
-                    Snackbar snackbar = Snackbar.make(getView(), errorMessage,
-                            Snackbar.LENGTH_INDEFINITE);
-                    snackbar.setAction("Retry", new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            fetchChapters();
-                        }
-                    });
-                    ColoredSnackBar.alert(snackbar).show();
-                }
+            public void failure(Throwable error) {
+                showError(R.string.fetch_chapters_failed);
+            }
+
+            @Override
+            public void networkFailure(Throwable error) {
+                showError(R.string.offline_alert);
             }
         });
+    }
+
+    @Override
+    protected void showError(@StringRes int errorStringRes) {
+        if (isContextValid()) {
+            if (getView() != null) {
+                Snackbar snackbar = Snackbar.make(getView(), errorStringRes,
+                        Snackbar.LENGTH_INDEFINITE);
+                snackbar.setAction("Retry", new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        fetchChapters();
+                    }
+                });
+                ColoredSnackBar.alert(snackbar).show();
+            } else {
+                Toast.makeText(getActivity(), errorStringRes, Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 
     private void addChapters(List<Chapter> chapterList) {

--- a/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
@@ -27,6 +27,7 @@ import android.widget.ViewSwitcher;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Chapter;
 import org.gdg.frisbee.android.api.model.Directory;
 import org.gdg.frisbee.android.app.App;
@@ -43,9 +44,6 @@ import java.util.List;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
-import retrofit.Callback;
-import retrofit.Response;
-import timber.log.Timber;
 
 public class FirstStartStep1Fragment extends BaseFragment {
 
@@ -115,8 +113,7 @@ public class FirstStartStep1Fragment extends BaseFragment {
 
         App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
             @Override
-            public void onResponse(Response<Directory> response) {
-                final Directory directory = response.body();
+            public void onSuccessResponse(Directory directory) {
 
                 if (isContextValid()) {
                     addChapters(directory.getGroups());
@@ -129,9 +126,12 @@ public class FirstStartStep1Fragment extends BaseFragment {
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Throwable t, int errorMessage) {
                 if (isContextValid()) {
-                    Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_chapters_failed,
+                    if (errorMessage != R.string.offline_alert) {
+                        errorMessage = R.string.fetch_chapters_failed;
+                    }
+                    Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                             Snackbar.LENGTH_INDEFINITE);
                     snackbar.setAction("Retry", new View.OnClickListener() {
                         @Override
@@ -141,7 +141,6 @@ public class FirstStartStep1Fragment extends BaseFragment {
                     });
                     ColoredSnackBar.alert(snackbar).show();
                 }
-                Timber.e(t, "Could'nt fetch chapter list");
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartStep1Fragment.java
@@ -44,8 +44,7 @@ import java.util.List;
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import retrofit.Callback;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
+import retrofit.Response;
 import timber.log.Timber;
 
 public class FirstStartStep1Fragment extends BaseFragment {
@@ -114,10 +113,11 @@ public class FirstStartStep1Fragment extends BaseFragment {
     
     private void fetchChapters() {
 
-        App.getInstance().getGdgXHub().getDirectory(new Callback<Directory>() {
-
+        App.getInstance().getGdgXHub().getDirectory().enqueue(new Callback<Directory>() {
             @Override
-            public void success(final Directory directory, Response response) {
+            public void onResponse(Response<Directory> response) {
+                final Directory directory = response.body();
+
                 if (isContextValid()) {
                     addChapters(directory.getGroups());
                     mLoadSwitcher.setDisplayedChild(1);
@@ -129,7 +129,7 @@ public class FirstStartStep1Fragment extends BaseFragment {
             }
 
             @Override
-            public void failure(RetrofitError error) {
+            public void onFailure(Throwable t) {
                 if (isContextValid()) {
                     Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_chapters_failed,
                             Snackbar.LENGTH_INDEFINITE);
@@ -141,7 +141,7 @@ public class FirstStartStep1Fragment extends BaseFragment {
                     });
                     ColoredSnackBar.alert(snackbar).show();
                 }
-                Timber.e(error, "Could'nt fetch chapter list");
+                Timber.e(t, "Could'nt fetch chapter list");
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -104,7 +104,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     private void fetchPulse(final String selectedPulse) {
         App.getInstance().getGroupDirectory().getPulse().enqueue(new Callback<Pulse>() {
             @Override
-            public void onSuccessResponse(final Pulse pulse) {
+            public void success(final Pulse pulse) {
                 App.getInstance().getModelCache().putAsync(
                         Const.CACHE_KEY_PULSE_GLOBAL,
                         pulse,
@@ -119,7 +119,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
             }
 
             @Override
-            public void onFailure(Throwable t, int errorMessage) {
+            public void failure(Throwable t, int errorMessage) {
                 try {
                     Snackbar snackbar = Snackbar.make(mContentLayout, errorMessage,
                             Snackbar.LENGTH_SHORT);

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -48,8 +48,7 @@ import java.util.Collections;
 
 import butterknife.Bind;
 import retrofit.Callback;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
+import retrofit.Response;
 import timber.log.Timber;
 
 public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment.Callbacks {
@@ -105,9 +104,10 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     }
 
     private void fetchPulse(final String selectedPulse) {
-        App.getInstance().getGroupDirectory().getPulse(new Callback<Pulse>() {
+        App.getInstance().getGroupDirectory().getPulse().enqueue(new Callback<Pulse>() {
             @Override
-            public void success(final Pulse pulse, Response response) {
+            public void onResponse(Response<Pulse> response) {
+                final Pulse pulse = response.body();
                 App.getInstance().getModelCache().putAsync(
                         Const.CACHE_KEY_PULSE_GLOBAL,
                         pulse,
@@ -122,14 +122,14 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
             }
 
             @Override
-            public void failure(RetrofitError error) {
+            public void onFailure(Throwable t) {
                 try {
                     Snackbar snackbar = Snackbar.make(mContentLayout, R.string.fetch_chapters_failed,
                             Snackbar.LENGTH_SHORT);
                     ColoredSnackBar.alert(snackbar).show();
                 } catch (IllegalStateException ignored) {
                 }
-                Timber.e(error, "Couldn't fetch chapter list");
+                Timber.e(t, "Couldn't fetch chapter list");
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -94,7 +94,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
 
     @Override
     public void onBackPressed() {
-        if (!PulseFragment.GLOBAL.equals(mSpinner.getSelectedItem())) {
+        if (mSpinner != null && !PulseFragment.GLOBAL.equals(mSpinner.getSelectedItem())) {
             openPulse(PulseFragment.GLOBAL);
             return;
         }
@@ -208,7 +208,9 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString(INSTANCE_STATE_SELECTED_PULSE, (String) mSpinner.getSelectedItem());
+        if (mSpinner != null) {
+            outState.putString(INSTANCE_STATE_SELECTED_PULSE, (String) mSpinner.getSelectedItem());
+        }
     }
 
     public class PulsePagerAdapter extends FragmentStatePagerAdapter {

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -18,7 +18,6 @@ package org.gdg.frisbee.android.pulse;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -31,7 +30,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.FrameLayout;
 import android.widget.Spinner;
 
 import org.gdg.frisbee.android.Const;
@@ -41,7 +39,6 @@ import org.gdg.frisbee.android.api.model.Pulse;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.common.GdgNavDrawerActivity;
-import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
@@ -57,9 +54,6 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
 
     @Bind(R.id.tabs)
     TabLayout mTabLayout;
-
-    @Bind(R.id.content_frame)
-    FrameLayout mContentLayout;
 
     private ArrayAdapter<String> mSpinnerAdapter;
     private PulsePagerAdapter mViewPagerAdapter;
@@ -119,13 +113,13 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
             }
 
             @Override
-            public void failure(Throwable t, int errorMessage) {
-                try {
-                    Snackbar snackbar = Snackbar.make(mContentLayout, errorMessage,
-                            Snackbar.LENGTH_SHORT);
-                    ColoredSnackBar.alert(snackbar).show();
-                } catch (IllegalStateException ignored) {
-                }
+            public void failure(Throwable error) {
+                showError(R.string.fetch_chapters_failed);
+            }
+
+            @Override
+            public void networkFailure(Throwable error) {
+                showError(R.string.offline_alert);
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -36,6 +36,7 @@ import android.widget.Spinner;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Pulse;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
@@ -47,9 +48,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import butterknife.Bind;
-import retrofit.Callback;
-import retrofit.Response;
-import timber.log.Timber;
 
 public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment.Callbacks {
 
@@ -106,8 +104,7 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     private void fetchPulse(final String selectedPulse) {
         App.getInstance().getGroupDirectory().getPulse().enqueue(new Callback<Pulse>() {
             @Override
-            public void onResponse(Response<Pulse> response) {
-                final Pulse pulse = response.body();
+            public void onSuccessResponse(final Pulse pulse) {
                 App.getInstance().getModelCache().putAsync(
                         Const.CACHE_KEY_PULSE_GLOBAL,
                         pulse,
@@ -122,14 +119,13 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Throwable t, int errorMessage) {
                 try {
-                    Snackbar snackbar = Snackbar.make(mContentLayout, R.string.fetch_chapters_failed,
+                    Snackbar snackbar = Snackbar.make(mContentLayout, errorMessage,
                             Snackbar.LENGTH_SHORT);
                     ColoredSnackBar.alert(snackbar).show();
                 } catch (IllegalStateException ignored) {
                 }
-                Timber.e(t, "Couldn't fetch chapter list");
             }
         });
     }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
@@ -27,11 +27,12 @@ import android.widget.ListView;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
-import org.gdg.frisbee.android.chapter.MainActivity;
+import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.Pulse;
 import org.gdg.frisbee.android.api.model.PulseEntry;
 import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
+import org.gdg.frisbee.android.chapter.MainActivity;
 import org.gdg.frisbee.android.common.GdgListFragment;
 import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.DateTime;
@@ -39,9 +40,6 @@ import org.joda.time.DateTime;
 import java.util.Map;
 
 import butterknife.ButterKnife;
-import retrofit.Callback;
-import retrofit.Response;
-import timber.log.Timber;
 
 public class PulseFragment extends GdgListFragment {
 
@@ -116,8 +114,7 @@ public class PulseFragment extends GdgListFragment {
         if (mTarget.equals(GLOBAL)) {
             App.getInstance().getGroupDirectory().getPulse().enqueue(new Callback<Pulse>() {
                 @Override
-                public void onResponse(Response<Pulse> response) {
-                    final Pulse pulse = response.body();
+                public void onSuccessResponse(final Pulse pulse) {
                     App.getInstance().getModelCache().putAsync(
                             Const.CACHE_KEY_PULSE + mTarget.toLowerCase(),
                             pulse,
@@ -131,20 +128,18 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable t, int errorMessage) {
                     if (isAdded()) {
-                        Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_chapters_failed,
+                        Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                                 Snackbar.LENGTH_SHORT);
                         ColoredSnackBar.alert(snackbar).show();
                     }
-                    Timber.e(t, "Couldn't fetch pulse");
                 }
             });
         } else {
             App.getInstance().getGroupDirectory().getCountryPulse(mTarget).enqueue(new Callback<Pulse>() {
                 @Override
-                public void onResponse(Response<Pulse> response) {
-                    final Pulse pulse = response.body();
+                public void onSuccessResponse(final Pulse pulse) {
                     App.getInstance().getModelCache().putAsync(
                             Const.CACHE_KEY_PULSE + mTarget.toLowerCase().replace(" ", "-"),
                             pulse,
@@ -158,13 +153,12 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable t, int errorMessage) {
                     if (isAdded()) {
-                        Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_chapters_failed,
+                        Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                                 Snackbar.LENGTH_SHORT);
                         ColoredSnackBar.alert(snackbar).show();
                     }
-                    Timber.e(t, "Couldn't fetch pulse");
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 import butterknife.ButterKnife;
 import retrofit.Callback;
-import retrofit.RetrofitError;
+import retrofit.Response;
 import timber.log.Timber;
 
 public class PulseFragment extends GdgListFragment {
@@ -114,9 +114,10 @@ public class PulseFragment extends GdgListFragment {
 
     private void fetchPulseTask() {
         if (mTarget.equals(GLOBAL)) {
-            App.getInstance().getGroupDirectory().getPulse(new Callback<Pulse>() {
+            App.getInstance().getGroupDirectory().getPulse().enqueue(new Callback<Pulse>() {
                 @Override
-                public void success(final Pulse pulse, retrofit.client.Response response) {
+                public void onResponse(Response<Pulse> response) {
+                    final Pulse pulse = response.body();
                     App.getInstance().getModelCache().putAsync(
                             Const.CACHE_KEY_PULSE + mTarget.toLowerCase(),
                             pulse,
@@ -130,19 +131,20 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void failure(RetrofitError error) {
+                public void onFailure(Throwable t) {
                     if (isAdded()) {
                         Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_chapters_failed,
                                 Snackbar.LENGTH_SHORT);
                         ColoredSnackBar.alert(snackbar).show();
                     }
-                    Timber.e(error, "Couldn't fetch pulse");
+                    Timber.e(t, "Couldn't fetch pulse");
                 }
             });
         } else {
-            App.getInstance().getGroupDirectory().getCountryPulse(mTarget, new Callback<Pulse>() {
+            App.getInstance().getGroupDirectory().getCountryPulse(mTarget).enqueue(new Callback<Pulse>() {
                 @Override
-                public void success(final Pulse pulse, retrofit.client.Response response) {
+                public void onResponse(Response<Pulse> response) {
+                    final Pulse pulse = response.body();
                     App.getInstance().getModelCache().putAsync(
                             Const.CACHE_KEY_PULSE + mTarget.toLowerCase().replace(" ", "-"),
                             pulse,
@@ -156,13 +158,13 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void failure(RetrofitError error) {
+                public void onFailure(Throwable t) {
                     if (isAdded()) {
                         Snackbar snackbar = Snackbar.make(getView(), R.string.fetch_chapters_failed,
                                 Snackbar.LENGTH_SHORT);
                         ColoredSnackBar.alert(snackbar).show();
                     }
-                    Timber.e(error, "Couldn't fetch pulse");
+                    Timber.e(t, "Couldn't fetch pulse");
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
@@ -19,7 +19,6 @@ package org.gdg.frisbee.android.pulse;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -34,7 +33,6 @@ import org.gdg.frisbee.android.app.App;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.chapter.MainActivity;
 import org.gdg.frisbee.android.common.GdgListFragment;
-import org.gdg.frisbee.android.view.ColoredSnackBar;
 import org.joda.time.DateTime;
 
 import java.util.Map;
@@ -128,12 +126,13 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void failure(Throwable t, int errorMessage) {
-                    if (isAdded()) {
-                        Snackbar snackbar = Snackbar.make(getView(), errorMessage,
-                                Snackbar.LENGTH_SHORT);
-                        ColoredSnackBar.alert(snackbar).show();
-                    }
+                public void failure(Throwable error) {
+                    showError(R.string.server_error);
+                }
+
+                @Override
+                public void networkFailure(Throwable error) {
+                    showError(R.string.offline_alert);
                 }
             });
         } else {
@@ -153,12 +152,13 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void failure(Throwable t, int errorMessage) {
-                    if (isAdded()) {
-                        Snackbar snackbar = Snackbar.make(getView(), errorMessage,
-                                Snackbar.LENGTH_SHORT);
-                        ColoredSnackBar.alert(snackbar).show();
-                    }
+                public void failure(Throwable error) {
+                    showError(R.string.server_error);
+                }
+
+                @Override
+                public void networkFailure(Throwable error) {
+                    showError(R.string.offline_alert);
                 }
             });
         }

--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseFragment.java
@@ -114,7 +114,7 @@ public class PulseFragment extends GdgListFragment {
         if (mTarget.equals(GLOBAL)) {
             App.getInstance().getGroupDirectory().getPulse().enqueue(new Callback<Pulse>() {
                 @Override
-                public void onSuccessResponse(final Pulse pulse) {
+                public void success(final Pulse pulse) {
                     App.getInstance().getModelCache().putAsync(
                             Const.CACHE_KEY_PULSE + mTarget.toLowerCase(),
                             pulse,
@@ -128,7 +128,7 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void onFailure(Throwable t, int errorMessage) {
+                public void failure(Throwable t, int errorMessage) {
                     if (isAdded()) {
                         Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                                 Snackbar.LENGTH_SHORT);
@@ -139,7 +139,7 @@ public class PulseFragment extends GdgListFragment {
         } else {
             App.getInstance().getGroupDirectory().getCountryPulse(mTarget).enqueue(new Callback<Pulse>() {
                 @Override
-                public void onSuccessResponse(final Pulse pulse) {
+                public void success(final Pulse pulse) {
                     App.getInstance().getModelCache().putAsync(
                             Const.CACHE_KEY_PULSE + mTarget.toLowerCase().replace(" ", "-"),
                             pulse,
@@ -153,7 +153,7 @@ public class PulseFragment extends GdgListFragment {
                 }
 
                 @Override
-                public void onFailure(Throwable t, int errorMessage) {
+                public void failure(Throwable t, int errorMessage) {
                     if (isAdded()) {
                         Snackbar snackbar = Snackbar.make(getView(), errorMessage,
                                 Snackbar.LENGTH_SHORT);

--- a/app/src/main/java/org/gdg/frisbee/android/view/DividerItemDecoration.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/DividerItemDecoration.java
@@ -10,13 +10,6 @@ import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
 
-/**
- * Created by <a href="mailto:marcusandreog@gmail.com">Marcus Gabilheri</a>
- *
- * @author Marcus Gabilheri
- * @version 1.0
- * @since 7/26/15.
- */
 public class DividerItemDecoration extends RecyclerView.ItemDecoration {
 
     private Drawable mDivider;

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ ext {
     jodaTimeVersion = '2.9.1'
     leakCanaryVersion = '1.3.1'
     okHttpVersion = '2.6.0'
+    retrofitVersion = '2.0.0-beta2'
 
     //test dependencies
     junitVersion = '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ ext {
     playServicesVersion = '7.8.0'
     jodaTimeVersion = '2.9.1'
     leakCanaryVersion = '1.3.1'
-    okHttpVersion = '2.6.0'
-    retrofitVersion = '2.0.0-beta2'
+    okHttpVersion = '3.0.0-RC1'
+    retrofitVersion = '2.0.0-beta3'
 
     //test dependencies
     junitVersion = '4.12'

--- a/settings/proguard/proguard-square-retrofit.pro
+++ b/settings/proguard/proguard-square-retrofit.pro
@@ -9,3 +9,6 @@
 -keepclasseswithmembers class * {
     @retrofit.http.* <methods>;
 }
+
+-keepattributes Signature
+-keepattributes Exceptions


### PR DESCRIPTION
Retrofit 2 integration is done. We may keep this un-merged because Retrofit 2 is still in beta. Once its released there won't be too much API changes and I think this PR will not change at all. I would like to get this reviewed before hand. 

Logging is removed from Retrofit. We were not using it at all. But I add beautiful logging using OkHttp interceptors for Debug builds. 

Created custom high level Callback abstract class that implements retrofit.Callback.

With this I can log actual network errors to Crashlytics with `Timber.e()` automatically. When there is no internet connection in a device, we are logging these. That's why we have Level 5 network errors in Crashlytics like [this](http://crashes.to/s/40f1de1941b). Those should be logged only with debug log.

Moreover, when there is an internet connection error. It is passed to the caller so that they can show `SnackBar` with appropriate network error.

Fixes #484 