### PR TITLE
Added keys for debug builds to ease the onboarding experience

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,9 +117,9 @@ android {
             versionNameSuffix "-debug"
             signingConfig signingConfigs.debug
 
-            buildConfigField "String", "IP_SIMPLE_API_ACCESS_KEY", "\"AIzaSyBhJJeiBWKTfbV446m2sgJCP-EogEWZUh0\""
-            buildConfigField "String", "ANDROID_SIMPLE_API_ACCESS_KEY", "\"AIzaSyD4B78bwtz5vgFqPO7sxY_R4XDhI6Fk2F4\""
-            resValue "string", "android_simple_api_access_key", "AIzaSyD4B78bwtz5vgFqPO7sxY_R4XDhI6Fk2F4"
+            buildConfigField "String", "IP_SIMPLE_API_ACCESS_KEY", "\"$local_properties.ip_simple_api_access_key_debug\""
+            buildConfigField "String", "ANDROID_SIMPLE_API_ACCESS_KEY", "\"$local_properties.android_simple_api_access_key_debug\""
+            resValue "string", "android_simple_api_access_key", local_properties.android_simple_api_access_key_debug ?: ""
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,16 +55,12 @@ android {
         buildConfigField "Boolean", "ALPHA", "false"
         
         //KEYS
-        buildConfigField "String", "ANDROID_SIMPLE_API_ACCESS_KEY", "\"" + (local_properties.android_simple_api_access_key ?: "") + "\""
-        buildConfigField "String", "IP_SIMPLE_API_ACCESS_KEY", "\"" + (local_properties.ip_simple_api_access_key ?: "") + "\""
         buildConfigField "String", "HUB_CLIENT_ID", "\"" + (local_properties.hub_client_id ?: "") + "\""
-        buildConfigField "String", "PLAY_APP_ID", "\"" + (local_properties.play_app_id ?: "") + "\""
         buildConfigField "String", "GCM_SENDER_ID", "\"" + (local_properties.gcm_sender_id ?: "") + "\""
         buildConfigField "long", "DOORBELL_ID", local_properties.doorbell_id ?: "0"
         buildConfigField "String", "DOORBELL_APP_KEY", "\"" + (local_properties.doorbell_app_key ?: "") + "\""
-        resValue "string", "play_app_id", local_properties.play_app_id ?: ""
+        resValue "string", "play_app_id", "429371117063"
         resValue "string", "android_backup_key", local_properties.android_backup_key ?: ""
-        resValue "string", "android_simple_api_access_key", local_properties.android_simple_api_access_key ?: ""
     }
 
     signingConfigs {
@@ -104,6 +100,10 @@ android {
             shrinkResources true
             debuggable false
             signingConfig signingConfigs.release
+
+            buildConfigField "String", "IP_SIMPLE_API_ACCESS_KEY", "\"$local_properties.ip_simple_api_access_key\""
+            buildConfigField "String", "ANDROID_SIMPLE_API_ACCESS_KEY", "\"$local_properties.android_simple_api_access_key\""
+            resValue "string", "android_simple_api_access_key", local_properties.android_simple_api_access_key ?: ""
         }
         alpha.initWith(release)
         alpha {
@@ -116,6 +116,10 @@ android {
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
             signingConfig signingConfigs.debug
+
+            buildConfigField "String", "IP_SIMPLE_API_ACCESS_KEY", "\"AIzaSyBhJJeiBWKTfbV446m2sgJCP-EogEWZUh0\""
+            buildConfigField "String", "ANDROID_SIMPLE_API_ACCESS_KEY", "\"AIzaSyD4B78bwtz5vgFqPO7sxY_R4XDhI6Fk2F4\""
+            resValue "string", "android_simple_api_access_key", "AIzaSyD4B78bwtz5vgFqPO7sxY_R4XDhI6Fk2F4"
         }
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/onboarding/StartActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/onboarding/StartActivity.java
@@ -32,7 +32,7 @@ public class StartActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (BuildConfig.DEBUG && TextUtils.isEmpty(BuildConfig.PLAY_APP_ID)) {
+        if (BuildConfig.DEBUG && TextUtils.isEmpty(BuildConfig.IP_SIMPLE_API_ACCESS_KEY)) {
             Toast.makeText(this, "no API keys defined!", Toast.LENGTH_SHORT).show();
         }
 

--- a/app/src/main/java/org/gdg/frisbee/android/onboarding/StartActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/onboarding/StartActivity.java
@@ -33,7 +33,7 @@ public class StartActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         if (BuildConfig.DEBUG && TextUtils.isEmpty(BuildConfig.IP_SIMPLE_API_ACCESS_KEY)) {
-            Toast.makeText(this, "no API keys defined!", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "No API keys defined!\nPlease check Github project Wiki page for more detail.", Toast.LENGTH_LONG).show();
         }
 
         Intent intentForStart;


### PR DESCRIPTION
I've been thinking about this for a long time. 

Google uses these keys for rate limiting and quota purposes. Our API usage does not have quota. 
I have created two new keys in the console for debug builds. Even if they are stolen(!) and used excessively, we can just replace them. It won't affect production too. Does it make sense to you all?

And `play_app_id` was already in the source control in [this file](https://github.com/gdg-x/frisbee/blob/develop/app/src/main/res/values/games-ids.xml). It is also not private. No one can do anything with it. Google makes signature control when it is used. 

Please comment on and correct me if I wrong. 

I erased my `local.properties` file and application worked perfectly. 