### PR TITLE
Library updates.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'io.fabric'
 apply plugin: 'com.github.triplet.play'
 apply plugin: 'checkstyle'
+apply plugin: 'com.getkeepsafe.dexcount'
 
 preBuild.dependsOn('checkstyle')
 assemble.dependsOn('lint')
@@ -161,7 +162,7 @@ configurations {
 
 dependencies {
 
-    def supportVersion = "23.0.1"
+    def supportVersion = "23.1.0"
     def playServicesVersion = "7.8.0"
 
     //Android Support
@@ -204,12 +205,12 @@ dependencies {
 
     //Jake Wharton
     compile 'com.jakewharton:butterknife:7.0.1'
-    compile 'com.jakewharton.timber:timber:3.1.0'
+    compile 'com.jakewharton.timber:timber:4.0.1'
     compile 'com.jakewharton:disklrucache:2.0.2'
 
     //Others
     compile 'io.doorbell:android-sdk:0.2.2@aar'
-    compile 'org.jsoup:jsoup:1.8.2'
+    compile 'org.jsoup:jsoup:1.8.3'
     compile 'net.danlew:android.joda:2.8.2'
     compile 'com.google.code.findbugs:jsr305:2.0.1'
     compile('com.crashlytics.sdk.android:crashlytics:2.5.2@aar') {
@@ -222,7 +223,7 @@ dependencies {
     //Test
     testCompile 'junit:junit:4.12'
     androidTestCompile 'org.assertj:assertj-core:1.7.1'
-    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.2') {
+    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.2.1') {
         exclude module: 'support-annotations'
     }
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -36,3 +36,5 @@
 -keepnames class * implements android.os.Parcelable {
     public static final ** CREATOR;
 }
+
+-dontwarn org.jetbrains.annotations.**

--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,14 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.4.0-beta1'
+        classpath 'com.android.tools.build:gradle:1.4.0-beta6'
         classpath 'com.google.gms:google-services:1.4.0-beta1'
 
-        classpath 'io.fabric.tools:gradle:1.19.2'
-        classpath 'com.github.triplet.gradle:play-publisher:1.1.3'
+        classpath 'io.fabric.tools:gradle:1.20.1'
+        classpath 'com.github.triplet.gradle:play-publisher:1.1.4'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.11.3'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.2.1'
+
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip


### PR DESCRIPTION
GMS is not updated to 8.1.0 because 8.1.0 has lots of problems,
Analytics makes the app larger, and apostate package seems to be empty.

and dex-count gradle plugin is added. 