### PR TITLE
minSdkVersion is now taken from command line property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Read the [Development Guide](https://github.com/gdg-x/frisbee/wiki/Developer-Doc
 
 When sending pull requests please make sure to enable EditorConfig in Android Studio -> Settings -> Editor -> Code & Style -> EditorConfig.
 
+####Speeding up debug builds
+
+The project uses multidex. To speed up the builds you need to set `minSdkLevel` to 21 and above. Our project uses 
+`minSdk` property to override `minSdkLevel`. To do that, you should open Android Studio Compiler Settings and add a 
+command line property like below: `-PminSdk=21`
+
+![Android Studio Compiler Settings]
+(https://cloud.githubusercontent.com/assets/763339/13549170/1f9fa1c8-e2f8-11e5-846d-fcd37616692c.png)
 
 ###Contributors
 See [list of contributors](https://github.com/gdg-x/frisbee/graphs/contributors)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,21 +90,6 @@ android {
         }
     }
 
-    productFlavors {
-        prod
-        dev {
-            minSdkVersion 21
-        }
-    }
-
-    variantFilter { variant ->
-        if (variant.getFlavors().get(0).name.equals('dev')
-            && (variant.buildType.name.equals('release')
-            || variant.buildType.name.equals('alpha'))) {
-            variant.setIgnore(true);
-        }
-    }
-
     lintOptions {
         abortOnError true
         checkReleaseBuilds false
@@ -207,7 +192,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // Android Wear
-    prodWearApp project(':wear')
+    wearApp project(':wear')
 
     // Dependencies for local unit tests
     testCompile "junit:junit:$rootProject.junitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta4'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
         classpath 'com.google.gms:google-services:1.3.1'
 
         classpath 'io.fabric.tools:gradle:1.21.2'
@@ -54,7 +54,7 @@ ext {
     versionName = "${versionMajor}.${versionMinor}.${versionPatch}"
 
     // Sdk and tools
-    minSdkVersion = 16
+    minSdkVersion = project.hasProperty("minSdk") ? minSdk : 16
     targetSdkVersion = 21
     compileSdkVersion = 23
     buildToolsVersion = '23.0.2'


### PR DESCRIPTION
The default value for minSdkLevel is always 16. When Travis is publishing Apk to Play Store or we do a release build by command line, it will be 16. 

It can be easily turned to 21/22/23 for faster debug builds by providing `minSdk` property. 

This property can be set using Android Studio compiler settings. 

![screen shot 2016-03-05 at 17 31 27](https://cloud.githubusercontent.com/assets/763339/13549170/1f9fa1c8-e2f8-11e5-846d-fcd37616692c.png)

More info can be found [here](http://artemzin.com/blog/minsdk-without-flavors/)

Fixes #565 