### PR TITLE
Remove unnecessary proguard rule. 

### DIFF
--- a/settings/proguard/proguard-support-v7-appcompat.pro
+++ b/settings/proguard/proguard-support-v7-appcompat.pro
@@ -5,8 +5,3 @@
 -keep public class * extends android.support.v4.view.ActionProvider {
     public <init>(android.content.Context);
 }
-
-# Workaround for Samsung Android 4.2 bug
-# https://code.google.com/p/android/issues/detail?id=78377
-# https://code.google.com/p/android/issues/detail?id=78377#c188
--keep class !android.support.v7.internal.view.menu.**,** {*;}


### PR DESCRIPTION
According to this, this problem is fixed. I heard somewhere that this can be removed. When it is removed, proguard will save use more space.

https://code.google.com/p/android/issues/detail?id=78377

I've alse searched for this crash in Fabric. We don't have the crash mentioned in the bug report. So it will be safe to remove this.