### PR TITLE
595/Check for connected games api in AchievementActionHandler

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/achievements/AchievementActionHandler.java
+++ b/app/src/main/java/org/gdg/frisbee/android/achievements/AchievementActionHandler.java
@@ -102,7 +102,7 @@ public class AchievementActionHandler {
             return;
         }
 
-        if (!mGoogleApi.isConnected()) {
+        if (!mGoogleApi.hasConnectedApi(Games.API)) {
             mPending.add(achievementName);
         } else {
             Games.Achievements.unlock(mGoogleApi, achievementName);
@@ -114,7 +114,7 @@ public class AchievementActionHandler {
         if (PrefUtils.hasHigherAchievementSteps(mContext, achievementName, steps)) {
             return;
         }
-        if (!mGoogleApi.isConnected()) {
+        if (!mGoogleApi.hasConnectedApi(Games.API)) {
             final Pair<String, Integer> achievement = new Pair<>(achievementName, steps);
             mPendingIncremental.add(achievement);
         } else {
@@ -124,6 +124,9 @@ public class AchievementActionHandler {
     }
 
     public void onConnected() {
+        if (!mGoogleApi.hasConnectedApi(Games.API)) {
+            return;
+        }
         for (String achievement : mPending) {
             postAchievementUnlockedEvent(achievement);
         }


### PR DESCRIPTION
This PR fixes #595 by checking for connected `Game.API`