### PR TITLE
598/fix login

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -274,12 +274,6 @@ public abstract class GdgActivity extends TrackableActivity implements
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult result) {
         if (mSignInProgress != STATE_IN_PROGRESS) {
-            if (isFatalPlayServiceError(result.getErrorCode())) {
-                if (PrefUtils.shouldShowFatalPlayServiceMessage(this)) {
-                    showFatalPlayServiceMessage(result);
-                }
-                return;
-            }
 
             // We do not have an intent in progress so we should store the latest
             // error resolution intent for use when the sign in button is clicked.
@@ -302,10 +296,6 @@ public abstract class GdgActivity extends TrackableActivity implements
         Timber.e("Google Play Service did not resolve error");
         GoogleApiAvailability.getInstance().showErrorNotification(this, result.getErrorCode());
         PrefUtils.setFatalPlayServiceMessageShown(this);
-    }
-
-    private boolean isFatalPlayServiceError(int errorCode) {
-        return !GoogleApiAvailability.getInstance().isUserResolvableError(errorCode);
     }
 
     public void setToolbarTitle(final String title) {

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -159,7 +159,7 @@ public abstract class GdgActivity extends TrackableActivity implements
      */
     protected GoogleApiClient createGoogleApiClient() {
         isSignedIn = PrefUtils.isSignedIn(this);
-        return GoogleApiClientFactory.createWith(getApplicationContext());
+        return GoogleApiClientFactory.createWith(this);
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -178,7 +178,7 @@ public class SettingsFragment extends PreferenceFragment {
     }
 
     private void createConnectedGoogleApiClient() {
-        mGoogleApiClient = GoogleApiClientFactory.createWith(getActivity().getApplicationContext());
+        mGoogleApiClient = GoogleApiClientFactory.createWith(getActivity());
         mGoogleApiClient.registerConnectionCallbacks((SettingsActivity) getActivity());
         mGoogleApiClient.registerConnectionFailedListener((SettingsActivity) getActivity());
         mGoogleApiClient.connect();


### PR DESCRIPTION
It seems that `isUserResolvableError` has problem. I suggest to remove it completely.

When GMS is not available, `resolveIntent` will be null and the dialog will be shown anyways. There is no  difference in that case. 

This will cause conflicts with @friedger 's open PR #608 

Fixes #598 