### PR TITLE
Remove model cache dir on app update

### DIFF
--- a/app/src/alpha/java/org/gdg/frisbee/android/app/BaseApp.java
+++ b/app/src/alpha/java/org/gdg/frisbee/android/app/BaseApp.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.support.v4.content.ContextCompat;
 import android.widget.Toast;
 
+import org.gdg.frisbee.android.utils.FileUtils;
 import org.gdg.frisbee.android.utils.PrefUtils;
 
 import java.io.File;
@@ -22,19 +23,10 @@ public class BaseApp extends Application {
         File[] cacheDirs = ContextCompat.getExternalCacheDirs(this);
         for (File cacheDir : cacheDirs) {
             if (cacheDir != null) {
-                deleteDirectory(cacheDir);
+                FileUtils.deleteDirectory(cacheDir);
             }
         }
-        deleteDirectory(getCacheDir());
+        FileUtils.deleteDirectory(getCacheDir());
     }
 
-    private boolean deleteDirectory(File dir) {
-        if (dir.isDirectory()) {
-            for (File child : dir.listFiles()) {
-                deleteDirectory(child);
-            }
-        }
-
-        return dir.delete();
-    }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -117,7 +117,7 @@ public class App extends BaseApp implements LocationListener {
         }
         mOkHttpClient = OkClientFactory.provideOkHttpClient(this);
 
-        // Initialize ModelCache and Volley
+        // Initialize ModelCache
         getModelCache();
 
         PrefUtils.increaseAppStartCount(this);
@@ -246,7 +246,7 @@ public class App extends BaseApp implements LocationListener {
             }
             final File rootDir = new File(cacheDir, "/model_cache/");
 
-            ModelCache.Builder builder = new ModelCache.Builder()
+            ModelCache.Builder builder = new ModelCache.Builder(this)
                 .setMemoryCacheEnabled(true);
             if (rootDir.isDirectory() || rootDir.mkdirs()) {
                 builder.setDiskCacheEnabled(true)

--- a/app/src/main/java/org/gdg/frisbee/android/app/App.java
+++ b/app/src/main/java/org/gdg/frisbee/android/app/App.java
@@ -52,6 +52,7 @@ import org.gdg.frisbee.android.api.PlusImageUrlConverter;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.eventseries.TaggedEventSeries;
 import org.gdg.frisbee.android.utils.CrashlyticsTree;
+import org.gdg.frisbee.android.utils.FileUtils;
 import org.gdg.frisbee.android.utils.GingerbreadLastLocationFinder;
 import org.gdg.frisbee.android.utils.PrefUtils;
 import org.gdg.frisbee.android.utils.Utils;
@@ -150,6 +151,13 @@ public class App extends BaseApp implements LocationListener {
         initTaggedEventSeries();
     }
 
+    @Override
+    protected void onAppUpdate(int oldVersion, int newVersion) {
+        super.onAppUpdate(oldVersion, newVersion);
+
+        File diskCacheLocation = getDiskCacheLocation();
+        FileUtils.deleteDirectory(diskCacheLocation);
+    }
 
     /**
      * Init TaggedEventSeries.
@@ -236,25 +244,28 @@ public class App extends BaseApp implements LocationListener {
         return mTracker;
     }
 
-    @NonNull
     public ModelCache getModelCache() {
         if (mModelCache == null) {
 
-            File cacheDir = getExternalCacheDir();
-            if (cacheDir == null) {
-                cacheDir = getCacheDir();
-            }
-            final File rootDir = new File(cacheDir, "/model_cache/");
+            final File rootDir = getDiskCacheLocation();
 
             ModelCache.Builder builder = new ModelCache.Builder(this)
                 .setMemoryCacheEnabled(true);
-            if (rootDir.isDirectory() || rootDir.mkdirs()) {
+            if (rootDir.mkdirs() || rootDir.isDirectory()) {
                 builder.setDiskCacheEnabled(true)
                     .setDiskCacheLocation(rootDir);
             }
             mModelCache = builder.build();
         }
         return mModelCache;
+    }
+
+    private File getDiskCacheLocation() {
+        File cacheDir = getExternalCacheDir();
+        if (cacheDir == null) {
+            cacheDir = getCacheDir();
+        }
+        return new File(cacheDir, "/model_cache/");
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
+++ b/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
@@ -16,6 +16,8 @@
 
 package org.gdg.frisbee.android.cache;
 
+import android.app.ActivityManager;
+import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Looper;
 import android.os.Process;
@@ -135,7 +137,7 @@ public class ModelCache {
     }
 
     public Object get(String url, boolean checkExpiration) {
-        Timber.d(String.format("get(%s)", url));
+        Timber.d("get(%s)", url);
         CacheItem result;
 
         // First try Memory Cache
@@ -299,7 +301,7 @@ public class ModelCache {
         mDiskCache = diskCache;
 
         if (null != diskCache) {
-            mDiskCacheEditLocks = new HashMap<String, ReentrantLock>();
+            mDiskCacheEditLocks = new HashMap<>();
             mDiskCacheFlusherExecutor = new ScheduledThreadPoolExecutor(1);
             mDiskCacheFlusherRunnable = new DiskCacheFlushRunnable(diskCache);
         }
@@ -416,8 +418,6 @@ public class ModelCache {
 
         static final int MEGABYTE = 1024 * 1024;
 
-        static final int DEFAULT_MEM_CACHE_MAX_SIZE = 32;
-
         static final int DEFAULT_DISK_CACHE_MAX_SIZE_MB = 10;
         private boolean mDiskCacheEnabled;
         private File mDiskCacheLocation;
@@ -425,13 +425,20 @@ public class ModelCache {
         private boolean mMemoryCacheEnabled;
         private int mMemoryCacheMaxSize;
 
-        public Builder() {
+        public Builder(Context context) {
             // Disk Cache is disabled by default, but it's default size is set
             mDiskCacheMaxSize = DEFAULT_DISK_CACHE_MAX_SIZE_MB * MEGABYTE;
 
             // Memory Cache is enabled by default, with a small maximum size
             mMemoryCacheEnabled = true;
-            mMemoryCacheMaxSize = DEFAULT_MEM_CACHE_MAX_SIZE;
+            mMemoryCacheMaxSize = calculateMemoryCacheSize(context);
+        }
+
+        static int calculateMemoryCacheSize(Context context) {
+            ActivityManager am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+            int memoryClass = am.getMemoryClass();
+            // Target ~6% of the available heap.
+            return MEGABYTE * memoryClass / 16;
         }
 
         private static long getHeapSize() {
@@ -513,8 +520,8 @@ public class ModelCache {
         }
 
         /**
-         * Set the maximum number of bytes the Memory Cache should use to store values. Defaults to
-         * {@value #DEFAULT_MEM_CACHE_MAX_SIZE}MB.
+         * Set the maximum number of bytes the Memory Cache should use to store values.
+         * Defaults to 1/16 of the available memory.
          *
          * @return This Builder object to allow for chaining of calls to set methods.
          */

--- a/app/src/main/java/org/gdg/frisbee/android/utils/FileUtils.java
+++ b/app/src/main/java/org/gdg/frisbee/android/utils/FileUtils.java
@@ -1,0 +1,20 @@
+package org.gdg.frisbee.android.utils;
+
+import java.io.File;
+
+public class FileUtils {
+
+    private FileUtils() {
+        //No instance
+    }
+
+    public static boolean deleteDirectory(File dir) {
+        if (dir.isDirectory()) {
+            for (File child : dir.listFiles()) {
+                deleteDirectory(child);
+            }
+        }
+
+        return dir.delete();
+    }
+}


### PR DESCRIPTION
On app update the app now deleted the model cache directory. This will prevent crashes related to model changes in the future. We had a lot of these crashes in the past. 

Fixes crash 262
http://crashes.to/s/b5fd72e0102