### PR TITLE
Fix crash related to DST

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/Const.java
+++ b/app/src/main/java/org/gdg/frisbee/android/Const.java
@@ -19,6 +19,7 @@ package org.gdg.frisbee.android;
 import android.text.format.DateUtils;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 public class Const {
 
@@ -29,17 +30,16 @@ public class Const {
     public static final String EXTRA_TAGGED_EVENT = "org.gdg.frisbee.TAGGED_EVENT";
     public static final String EXTRA_TAGGED_EVENT_CACHEKEY = "org.gdg.frisbee.TAGGED_EVENT_CACHEKEY";
     //Special Events Dates
-    public static final DateTime START_TIME_DEVFEST = new DateTime(2015, 9, 1, 0, 0);
-    public static final DateTime START_TIME_WTM = new DateTime(2016, 2, 1, 0, 0);
-    public static final DateTime START_TIME_STUDY_JAMS = new DateTime(2016, 1, 15, 0, 0);
-    public static final DateTime START_TIME_IOEXTENDED = new DateTime(2016, 5, 1, 0, 0);
-    public static final DateTime START_TIME_GCP_NEXT = new DateTime(2016, 3, 15, 0, 0);
-    public static final DateTime END_TIME_DEVFEST = new DateTime(2016, 1, 1, 0, 0);
-    public static final DateTime END_TIME_WTM = new DateTime(2016, 4, 1, 0, 0);
-    public static final DateTime END_TIME_STUDY_JAMS = new DateTime(2016, 5, 1, 0, 0);
-    public static final DateTime END_TIME_IOEXTENDED = new DateTime(2016, 6, 1, 0, 0);
-    public static final DateTime END_TIME_GCP_NEXT = new DateTime(2016, 4, 15, 0, 0);
-    public static final String EXTRA_PLUS_ID = "plus_id";
+    public static final DateTime START_TIME_DEVFEST = new DateTime(2015, 9, 1, 0, 0, DateTimeZone.UTC);
+    public static final DateTime START_TIME_WTM = new DateTime(2016, 2, 1, 0, 0, DateTimeZone.UTC);
+    public static final DateTime START_TIME_STUDY_JAMS = new DateTime(2016, 1, 15, 0, 0, DateTimeZone.UTC);
+    public static final DateTime START_TIME_IOEXTENDED = new DateTime(2016, 5, 1, 0, 0, DateTimeZone.UTC);
+    public static final DateTime START_TIME_GCP_NEXT = new DateTime(2016, 3, 15, 0, 0, DateTimeZone.UTC);
+    public static final DateTime END_TIME_DEVFEST = new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC);
+    public static final DateTime END_TIME_WTM = new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC);
+    public static final DateTime END_TIME_STUDY_JAMS = new DateTime(2016, 5, 1, 0, 0, DateTimeZone.UTC);
+    public static final DateTime END_TIME_IOEXTENDED = new DateTime(2016, 6, 1, 0, 0, DateTimeZone.UTC);
+    public static final DateTime END_TIME_GCP_NEXT = new DateTime(2016, 4, 15, 0, 0, DateTimeZone.UTC);
     //Navigation Drawer
     public static final int DRAWER_HOME = 0;
     public static final int DRAWER_PULSE = 2;
@@ -80,6 +80,7 @@ public class Const {
     public static final String URL_GDGROUPS_ORG = "https://gdgroups.org";
     public static final String PATH_GDGROUPS_ORG_EVENT = "event";
     //Keys
+    public static final String EXTRA_PLUS_ID = "plus_id";
     public static final String EXTRA_CHAPTER_ID = "org.gdg.frisbee.CHAPTER";
     public static final String CACHE_KEY_CHAPTER_LIST_HUB = "chapter_list_hub";
     public static final String CACHE_KEY_PULSE_GLOBAL = "pulse_global";


### PR DESCRIPTION
All dates are now UTC.

According to JodaTime, all date time objects should be valid. In some corner cases, because of the daylight saving times, some of them are invalid. When you create the object using UTC timezone, it will always be valid. This will fix crash 230, 264 http://crashes.to/s/3d775ef701f

More info
http://joda-time.sourceforge.net/apidocs/org/joda/time/IllegalInstantException.html
http://stackoverflow.com/questions/4983846/calculating-a-time-duration-with-joda-time