### PR TITLE
Several changes in PulseActivity. 

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/pulse/PulseActivity.java
@@ -55,10 +55,10 @@ public class PulseActivity extends GdgNavDrawerActivity implements PulseFragment
     @Bind(R.id.tabs)
     TabLayout mTabLayout;
 
-    private ArrayAdapter<String> mSpinnerAdapter;
-    private PulsePagerAdapter mViewPagerAdapter;
-    private ArrayList<String> mPulseTargets;
-    private Spinner mSpinner;
+    ArrayAdapter<String> mSpinnerAdapter;
+    PulsePagerAdapter mViewPagerAdapter;
+    ArrayList<String> mPulseTargets = new ArrayList<>();
+    Spinner mSpinner;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
- selectedPulse cannot be null anymore. It is passed to adapter by the constructor.
- Its default value is GLOBAL
- When we retrieve a Pulse object, `setupPulseScreen` is called.
- `setupPulseScreen` sets up the array, inits the Spinner and selects the default selected value in Spinner.
- `initSpinner` now only inits the Spinner.
- `onItemSelected` checks if the previous selected item is available and then setup the ViewPager with `onPulseItemSelected`
- method ordering is adjust to make it top down readable.
- PulsePagerAdapter is now a static class to prevent Context leaks.

Supposed to fix crash 237
http://crashes.to/s/cdcf7ea59c7