### PR TITLE
Selectable Texts are enabled for various screens

### DIFF
--- a/app/src/main/res/layout-land/activity_special.xml
+++ b/app/src/main/res/layout-land/activity_special.xml
@@ -79,6 +79,7 @@
               android:layout_height="wrap_content"
               android:padding="@dimen/keyline_1"
               tools:ignore="InconsistentLayout"
+              android:textIsSelectable="true"
               tools:text="@string/ioextended_description" />
           </ScrollView>
         </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/fragment_changelog.xml
+++ b/app/src/main/res/layout/fragment_changelog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:card_view="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
@@ -20,7 +21,12 @@
         android:id="@+id/changelog"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="8dp" />
+        android:padding="8dp"
+        android:textIsSelectable="true"
+        tools:text="Release 2.4, released on 22 Mar 2016\n
+* Google Sign-in improvements. Devices without Google Play Services will work now.\n
+* GCP NEXT Extended events are added to the drawer. \n
+* GDE page fixed. \n" />
     </ScrollView>
   </android.support.v7.widget.CardView>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_event_overview.xml
+++ b/app/src/main/res/layout/fragment_event_overview.xml
@@ -39,6 +39,7 @@
         android:layout_marginLeft="8dip"
         android:layout_toLeftOf="@+id/group_logo"
         android:textAppearance="?android:textAppearanceLarge"
+        android:textIsSelectable="true"
         tools:text="Event Title" />
 
       <TextView
@@ -64,19 +65,10 @@
         android:gravity="start"
         tools:text="Begin 20:15" />
 
-      <TextView
-        android:id="@+id/textView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/start_time"
-        android:layout_marginLeft="8dip"
-        android:layout_marginTop="10dip"
-        android:text="@string/event_description" />
-
       <android.support.v7.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/textView"
+        android:layout_below="@+id/start_time"
         android:layout_marginLeft="5dip"
         android:layout_marginRight="5dip"
         android:layout_marginTop="10dip"
@@ -88,6 +80,7 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:autoLink="all"
+          android:textIsSelectable="true"
           android:padding="5dip" />
       </android.support.v7.widget.CardView>
 

--- a/app/src/main/res/layout/fragment_external_libraries.xml
+++ b/app/src/main/res/layout/fragment_external_libraries.xml
@@ -21,8 +21,9 @@
         android:id="@+id/external"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:autoLink="web"
         android:padding="10dp"
+        android:autoLink="web"
+        android:textIsSelectable="true"
         tools:text="@string/about_third_party_libraries" />
     </ScrollView>
   </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/fragment_gde_about.xml
+++ b/app/src/main/res/layout/fragment_gde_about.xml
@@ -37,6 +37,7 @@
           android:id="@+id/textView2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:textIsSelectable="true"
           android:text="@string/gde_who_desc" />
       </LinearLayout>
     </android.support.v7.widget.CardView>
@@ -66,6 +67,7 @@
           android:id="@+id/textView4"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:textIsSelectable="true"
           android:text="@string/gde_what_desc" />
       </LinearLayout>
     </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/header_list_special_event_series.xml
+++ b/app/src/main/res/layout/header_list_special_event_series.xml
@@ -16,5 +16,6 @@
     android:drawablePadding="@dimen/content_padding"
     android:padding="@dimen/content_padding"
     tools:drawableTop="@drawable/ic_ioextended"
+    android:textIsSelectable="true"
     tools:text="@string/ioextended_description" />
 </android.support.v7.widget.CardView>


### PR DESCRIPTION
Some TextViews are made selectable for copy & paste. 
Lets discuss about them briefly. We can disable some of them if you like. 

Screens:
- The description about event series like DevFest etc. 
- Changelog
- Event Detail Title
- Event Detail Description
- 3rd party libraries. 
- GDE descriptions. 

Screenshots will be added later. 

Fixes #635