### PR TITLE
Feature/442 Cloud Messaging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -140,10 +140,10 @@ dependencies {
     //Play Services
     compile "com.google.android.gms:play-services-games:$rootProject.playServicesVersion"
     compile "com.google.android.gms:play-services-plus:$rootProject.playServicesVersion"
-    compile "com.google.android.gms:play-services-appstate:$rootProject.playServicesVersion"
     compile "com.google.android.gms:play-services-analytics:$rootProject.playServicesVersion"
     compile "com.google.android.gms:play-services-appinvite:$rootProject.playServicesVersion"
     compile "com.google.android.gms:play-services-appindexing:$rootProject.playServicesVersion"
+    compile "com.google.firebase:firebase-messaging:$rootProject.playServicesVersion"
 
     //Google
     compile 'com.google.android.apps.dashclock:dashclock-api:2.0.0'

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,18 +1,16 @@
 {
   "project_info": {
-    "project_id": "api-project-429371117063",
     "project_number": "429371117063",
-    "name": "GDGX"
+    "firebase_url": "https://api-project-429371117063.firebaseio.com",
+    "project_id": "api-project-429371117063",
+    "storage_bucket": "api-project-429371117063.appspot.com"
   },
   "client": [
     {
       "client_info": {
         "mobilesdk_app_id": "1:429371117063:android:d42e7ba907a05c43",
-        "client_id": "android:org.gdg.frisbee.android",
-        "client_type": 1,
         "android_client_info": {
-          "package_name": "org.gdg.frisbee.android",
-          "certificate_hash": []
+          "package_name": "org.gdg.frisbee.android"
         }
       },
       "oauth_client": [
@@ -64,14 +62,7 @@
       ],
       "services": {
         "analytics_service": {
-          "status": 2,
-          "analytics_property": {
-            "tracking_id": "UA-42015512-1"
-          }
-        },
-        "cloud_messaging_service": {
-          "status": 1,
-          "apns_config": []
+          "status": 1
         },
         "appinvite_service": {
           "status": 2,
@@ -82,9 +73,6 @@
             }
           ]
         },
-        "google_signin_service": {
-          "status": 2
-        },
         "ads_service": {
           "status": 1
         }
@@ -93,11 +81,8 @@
     {
       "client_info": {
         "mobilesdk_app_id": "1:429371117063:android:27fc93d6474f3957",
-        "client_id": "android:org.gdg.frisbee.android.debug",
-        "client_type": 1,
         "android_client_info": {
-          "package_name": "org.gdg.frisbee.android.debug",
-          "certificate_hash": []
+          "package_name": "org.gdg.frisbee.android.debug"
         }
       },
       "oauth_client": [
@@ -133,14 +118,7 @@
       ],
       "services": {
         "analytics_service": {
-          "status": 2,
-          "analytics_property": {
-            "tracking_id": "UA-42015512-1"
-          }
-        },
-        "cloud_messaging_service": {
-          "status": 1,
-          "apns_config": []
+          "status": 1
         },
         "appinvite_service": {
           "status": 2,
@@ -151,15 +129,11 @@
             }
           ]
         },
-        "google_signin_service": {
-          "status": 2
-        },
         "ads_service": {
           "status": 1
         }
       }
     }
   ],
-  "client_info": [],
-  "ARTIFACT_VERSION": "1"
+  "configuration_version": "1"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -240,6 +240,21 @@
         tools:ignore="ManifestResource" />
     </service>
 
+    <service
+      android:name=".messaging.MessagingService">
+      <intent-filter>
+        <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+      </intent-filter>
+    </service>
+
+    <service
+      android:name=".messaging.InstanceIdService">
+      <intent-filter>
+        <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
+      </intent-filter>
+    </service>
+
+
     <receiver
       android:name=".arrow.SummitNotificationReceiver"
       android:enabled="true"

--- a/app/src/main/java/org/gdg/frisbee/android/messaging/InstanceIdService.java
+++ b/app/src/main/java/org/gdg/frisbee/android/messaging/InstanceIdService.java
@@ -1,0 +1,6 @@
+package org.gdg.frisbee.android.messaging;
+
+import com.google.firebase.iid.FirebaseInstanceIdService;
+
+public class InstanceIdService extends FirebaseInstanceIdService {
+}

--- a/app/src/main/java/org/gdg/frisbee/android/messaging/MessagingService.java
+++ b/app/src/main/java/org/gdg/frisbee/android/messaging/MessagingService.java
@@ -1,0 +1,6 @@
+package org.gdg.frisbee.android.messaging;
+
+import com.google.firebase.messaging.FirebaseMessagingService;
+
+public class MessagingService extends FirebaseMessagingService {
+}

--- a/app/src/main/res/values/tracker.xml
+++ b/app/src/main/res/values/tracker.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="ga_trackingId">UA-42015512-1</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.0'
-        classpath 'com.google.gms:google-services:2.1.0'
+        classpath 'com.google.gms:google-services:3.0.0'
 
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'io.fabric.tools:gradle:1.21.6'
@@ -62,7 +62,7 @@ ext {
 
     // App dependencies
     supportLibraryVersion = '23.4.0'
-    playServicesVersion = '8.4.0'
+    playServicesVersion = '9.0.1'
     butterKnifeVersion = '8.0.1'
     jodaTimeVersion = '2.9.3'
     leakCanaryVersion = '1.3.1'


### PR DESCRIPTION
This PR uses Google Service plugin 3.0 and the firebase configuration for FCM.

This is the preparation for more messaging logic. For now, we can't send messages to users per chapter, just the usual when in background messages. More depends on the backend.

![screenshot_20160607-105354](https://cloud.githubusercontent.com/assets/1449049/15852108/426c6f5a-2ca0-11e6-9365-600253c7746a.png)
