### PR TITLE
sort gde categories in ascending order

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/gde/GdeActivity.java
@@ -19,6 +19,8 @@ import org.joda.time.DateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import butterknife.BindView;
 
@@ -85,8 +87,8 @@ public class GdeActivity extends GdgNavDrawerActivity implements ViewPager.OnPag
     }
 
     private void setupGdeViewPager(GdeList directory) {
-        // TODO use sorted HashMap to sort the categories.
-        HashMap<String, GdeList> gdeMap = extractCategoriesFromGdeList(directory);
+        SortedMap<String, GdeList> gdeMap = new TreeMap<>();
+        gdeMap.putAll(extractCategoriesFromGdeList(directory));
         List<GdeCategory> gdeCategoryList = convertCategoryMapToList(gdeMap);
 
         mViewPagerAdapter = new GdeCategoryPagerAdapter(
@@ -120,7 +122,7 @@ public class GdeActivity extends GdgNavDrawerActivity implements ViewPager.OnPag
         return gdeMap;
     }
 
-    private List<GdeCategory> convertCategoryMapToList(HashMap<String, GdeList> gdeMap) {
+    private List<GdeCategory> convertCategoryMapToList(SortedMap<String, GdeList> gdeMap) {
         List<GdeCategory> gdeCategoryList = new ArrayList<>();
         for (String category : gdeMap.keySet()) {
             GdeList gdeList = gdeMap.get(category);


### PR DESCRIPTION
I think GDE categories should be displayed in ascending order.

![screenshot_20160912-144230](https://cloud.githubusercontent.com/assets/888080/18430709/448efaf2-78f7-11e6-9399-d800d8181db3.png)
