### PR TITLE
Change TextView to Button to make it selectable by keyboard

### DIFF
--- a/app/src/main/res/layout/actionbar_chapter_selector.xml
+++ b/app/src/main/res/layout/actionbar_chapter_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@android:id/text1"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"


### PR DESCRIPTION
I was trying to change the chapter in the MainActivity by using just the keyboard. 

Dialog was working fine with the keyboard once it is open. The Chapter swapper was not focusable. I change TextView to Button and now it just works great.