### PR TITLE
Fix Travis not being able to push to release branch

### DIFF
--- a/.buildscript/deploy_alpha.sh
+++ b/.buildscript/deploy_alpha.sh
@@ -29,6 +29,10 @@ commitAndPushToGit () {
   local version=$1
   git config user.name "GDG-X"
   git config user.email "support@gdgx.io"
+  git stash
+  git checkout develop
+  git merge $BRANCH
+  git stash pop
   git add build.gradle
   git commit -m "Prepare for release $version"
   git tag -a $version -m "Version $version"


### PR DESCRIPTION
Since we now protect `release` branch, Travis cannot push it.
So the script now tries to merge the current branch back to develop and push the version change there.