### PR TITLE
Fix Chromebooks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,9 +5,8 @@
   package="org.gdg.frisbee.android"
   android:installLocation="auto">
 
-  <uses-feature
-    android:name="android.hardware.nfc"
-    android:required="false" />
+  <uses-feature android:name="android.hardware.nfc" android:required="false" />
+  <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Disable GPS requirement to be able to be installed on Chromebooks

Fixes #649