### PR TITLE
Issue #652: Links in Info page are not clickable

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -24,6 +24,7 @@ import android.text.Html;
 import android.text.Spanned;
 import android.text.SpannedString;
 import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -189,6 +190,7 @@ public class InfoFragment extends BaseFragment {
         TextView tv = (TextView) mInflater
             .inflate(R.layout.list_resource_item, (ViewGroup) getView(), false);
         tv.setText(Html.fromHtml("<a href='" + url.getValue() + "'>" + url.getLabel() + "</a>"));
+        tv.setMovementMethod(LinkMovementMethod.getInstance());
         mResourcesBox.addView(tv);
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -147,6 +147,7 @@ public class InfoFragment extends BaseFragment {
         }
         if (mAbout != null) {
             mAbout.setText(getAboutText(chapter));
+            mAbout.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 

--- a/app/src/main/res/layout/card_about_box.xml
+++ b/app/src/main/res/layout/card_about_box.xml
@@ -29,7 +29,6 @@
       android:id="@+id/about"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:autoLink="email|map|web"
       android:paddingBottom="4dp" />
   </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/list_resource_item.xml
+++ b/app/src/main/res/layout/list_resource_item.xml
@@ -2,5 +2,4 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:autoLink="all"
   android:padding="5dip"/>


### PR DESCRIPTION
Apparently, android:autoLink="all" won't work with html a tags, so we need to set LinkMovementMethod as the MovementMethod programmatically