### PR TITLE
refactor: update signingConfigs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,11 @@ local_properties.load(new FileInputStream(rootProject.file('local.properties')))
 apply from: '../settings/frisbee.gradle'
 
 android {
+    signingConfigs {
+        debug {
+            storeFile file('../settings/debug.keystore')
+        }
+    }
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 


### PR DESCRIPTION
set settings/debug.keystore as default for debug builds for G+ sign-in to work