### PR TITLE
fix: move login to nav drawer header

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -56,7 +56,7 @@ public abstract class GdgActivity extends TrackableActivity implements
     private static final int STATE_DEFAULT = 0;
     private static final int STATE_SIGN_IN = 1;
     private static final int STATE_IN_PROGRESS = 2;
-    public static final int RC_SIGN_IN = 101;
+    private static final int RC_SIGN_IN = 101;
     private static final String SAVED_PROGRESS = "SAVED_PROGRESS";
     @Nullable
     @BindView(R.id.content_frame)

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -56,7 +56,7 @@ public abstract class GdgActivity extends TrackableActivity implements
     private static final int STATE_DEFAULT = 0;
     private static final int STATE_SIGN_IN = 1;
     private static final int STATE_IN_PROGRESS = 2;
-    private static final int RC_SIGN_IN = 101;
+    public static final int RC_SIGN_IN = 101;
     private static final String SAVED_PROGRESS = "SAVED_PROGRESS";
     @Nullable
     @BindView(R.id.content_frame)

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -32,8 +32,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.google.android.gms.common.api.GoogleApiClient;
-
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.about.AboutActivity;
@@ -41,7 +39,6 @@ import org.gdg.frisbee.android.activity.SettingsActivity;
 import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.plus.Person;
 import org.gdg.frisbee.android.app.App;
-import org.gdg.frisbee.android.app.GoogleApiClientFactory;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.chapter.MainActivity;
 import org.gdg.frisbee.android.eventseries.TaggedEventSeries;
@@ -196,25 +193,10 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     private void onLoginClick() {
         if (!PrefUtils.isSignedIn(this)) {
             mDrawerLayout.closeDrawer(Gravity.LEFT);
-            if (getGoogleApiClient().isConnected()) {
-                disconnectGoogleApiClient();
-            }
-            PrefUtils.setSignedIn(this);
-            createConnectedGoogleApiClient();
+            PrefUtils.setSignedIn(GdgNavDrawerActivity.this);
+            recreateGoogleApiClientIfNeeded();
+            getGoogleApiClient().connect();
         }
-    }
-
-    private void createConnectedGoogleApiClient() {
-        GoogleApiClient googleApiClient = GoogleApiClientFactory.createWith(this);
-        googleApiClient.registerConnectionFailedListener(this);
-        googleApiClient.registerConnectionCallbacks(this);
-        googleApiClient.connect();
-    }
-
-    private void disconnectGoogleApiClient() {
-        getGoogleApiClient().unregisterConnectionCallbacks(this);
-        getGoogleApiClient().unregisterConnectionFailedListener(this);
-        getGoogleApiClient().disconnect();
     }
 
     void onDrawerItemClick(int itemId) {
@@ -319,19 +301,6 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         // Pass the event to ActionBarDrawerToggle, if it returns
         // true, then it has handled the app icon touch event
         return mDrawerToggle.onOptionsItemSelected(item) || super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int responseCode, Intent intent) {
-        if (PrefUtils.isSignedIn(this)) {
-            switch (requestCode) {
-                case GdgActivity.RC_SIGN_IN:
-                    if (responseCode == RESULT_OK) {
-                        updateUserDetails();
-                        recreate();
-                    }
-            }
-        }
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -21,14 +21,18 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.design.widget.NavigationView;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
+import android.text.TextUtils;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
@@ -37,6 +41,7 @@ import org.gdg.frisbee.android.activity.SettingsActivity;
 import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.plus.Person;
 import org.gdg.frisbee.android.app.App;
+import org.gdg.frisbee.android.app.GoogleApiClientFactory;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.chapter.MainActivity;
 import org.gdg.frisbee.android.eventseries.TaggedEventSeries;
@@ -47,7 +52,7 @@ import org.gdg.frisbee.android.pulse.PulseActivity;
 import org.gdg.frisbee.android.utils.PlusUtils;
 import org.gdg.frisbee.android.utils.PrefUtils;
 import org.gdg.frisbee.android.utils.Utils;
-import org.gdg.frisbee.android.view.BitmapBorderTransformation;
+import org.gdg.frisbee.android.view.CircleTransform;
 import org.joda.time.DateTime;
 
 import java.util.List;
@@ -85,6 +90,7 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     NavigationView mNavigationView;
     ImageView mDrawerImage;
     ImageView mDrawerUserPicture;
+    TextView mDrawerUserName;
     private ActionBarDrawerToggle mDrawerToggle;
 
     @Override
@@ -177,6 +183,38 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         View headerView = navigationView.getHeaderView(0);
         mDrawerImage = ButterKnife.findById(headerView, R.id.navdrawer_image);
         mDrawerUserPicture = ButterKnife.findById(headerView, R.id.navdrawer_user_picture);
+        mDrawerUserName = ButterKnife.findById(headerView, R.id.navdrawer_user_name);
+
+        headerView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                onLoginClick();
+            }
+        });
+    }
+
+    private void onLoginClick() {
+        if (!PrefUtils.isSignedIn(this)) {
+            mDrawerLayout.closeDrawer(Gravity.LEFT);
+            if (getGoogleApiClient().isConnected()) {
+                disconnectGoogleApiClient();
+            }
+            PrefUtils.setSignedIn(this);
+            createConnectedGoogleApiClient();
+        }
+    }
+
+    private void createConnectedGoogleApiClient() {
+        GoogleApiClient googleApiClient = GoogleApiClientFactory.createWith(this);
+        googleApiClient.registerConnectionFailedListener(this);
+        googleApiClient.registerConnectionCallbacks(this);
+        googleApiClient.connect();
+    }
+
+    private void disconnectGoogleApiClient() {
+        getGoogleApiClient().unregisterConnectionCallbacks(this);
+        getGoogleApiClient().unregisterConnectionFailedListener(this);
+        getGoogleApiClient().disconnect();
     }
 
     void onDrawerItemClick(int itemId) {
@@ -284,6 +322,19 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     }
 
     @Override
+    protected void onActivityResult(int requestCode, int responseCode, Intent intent) {
+        if (PrefUtils.isSignedIn(this)) {
+            switch (requestCode) {
+                case GdgActivity.RC_SIGN_IN:
+                    if (responseCode == RESULT_OK) {
+                        updateUserDetails();
+                        recreate();
+                    }
+            }
+        }
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
 
@@ -296,7 +347,7 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     @Override
     public void onConnected(final Bundle bundle) {
         super.onConnected(bundle);
-        updateUserPicture();
+        updateUserDetails();
     }
 
     @Override
@@ -318,18 +369,22 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         }
     }
 
-    private void updateUserPicture() {
+    private void updateUserDetails() {
         if (!PrefUtils.isSignedIn(this)) {
             mDrawerUserPicture.setImageDrawable(null);
+            mDrawerUserName.setText(R.string.login_register);
             return;
         }
         final String gplusId = PlusUtils.getCurrentPersonId(getGoogleApiClient());
         if (gplusId != null) {
             App.getInstance().getPicasso().load(PlusUtils.createProfileUrl(gplusId))
-                .transform(new BitmapBorderTransformation(2,
-                    getResources().getDimensionPixelSize(R.dimen.navdrawer_user_picture_size) / 2,
-                    ContextCompat.getColor(this, R.color.white)))
+                .transform(new CircleTransform())
                 .into(mDrawerUserPicture);
+        }
+
+        String name = PlusUtils.getCurrentPersonName(getGoogleApiClient());
+        if (!TextUtils.isEmpty(name)) {
+            mDrawerUserName.setText(name);
         }
     }
 

--- a/app/src/main/java/org/gdg/frisbee/android/utils/PlusUtils.java
+++ b/app/src/main/java/org/gdg/frisbee/android/utils/PlusUtils.java
@@ -22,6 +22,16 @@ public class PlusUtils {
         return plusPerson != null ? plusPerson.getId() : null;
     }
 
+    @Nullable
+    public static String getCurrentPersonName(GoogleApiClient apiClient) {
+        Person plusPerson = null;
+        if (apiClient.isConnected() && apiClient.hasConnectedApi(Plus.API)) {
+            plusPerson = Plus.PeopleApi.getCurrentPerson(apiClient);
+            return plusPerson.getDisplayName();
+        }
+        return null;
+    }
+
     public static Uri createProfileUrl(@NonNull final String gplusId) {
         return Uri.parse("https://plus.google.com/" + gplusId);
     }

--- a/app/src/main/java/org/gdg/frisbee/android/view/CircleTransform.java
+++ b/app/src/main/java/org/gdg/frisbee/android/view/CircleTransform.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2015 The GDG Frisbee Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gdg.frisbee.android.view;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.squareup.picasso.Transformation;
+
+public class CircleTransform implements Transformation {
+    @Override
+    public Bitmap transform(Bitmap source) {
+        int size = Math.min(source.getWidth(), source.getHeight());
+
+        int x = (source.getWidth() - size) / 2;
+        int y = (source.getHeight() - size) / 2;
+
+        Bitmap squaredBitmap = Bitmap.createBitmap(source, x, y, size, size);
+        if (squaredBitmap != source) {
+            source.recycle();
+        }
+
+        Bitmap bitmap = Bitmap.createBitmap(size, size, source.getConfig());
+
+        Canvas canvas = new Canvas(bitmap);
+        Paint paint = new Paint();
+        BitmapShader shader = new BitmapShader(squaredBitmap,
+            BitmapShader.TileMode.CLAMP, BitmapShader.TileMode.CLAMP);
+        paint.setShader(shader);
+        paint.setAntiAlias(true);
+
+        float r = size / 2f;
+        canvas.drawCircle(r, r, r, paint);
+
+        squaredBitmap.recycle();
+        return bitmap;
+    }
+
+    @Override
+    public String key() {
+        return "circle";
+    }
+}

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -25,7 +25,7 @@
     android:layout_height="@dimen/navdrawer_user_picture_size"
     android:layout_alignParentLeft="true"
     android:layout_alignParentStart="true"
-    android:layout_marginBottom="@dimen/keyline_1"
+    android:layout_marginBottom="@dimen/content_padding"
     android:layout_marginLeft="@dimen/keyline_1"
     android:layout_marginStart="@dimen/keyline_1"
     android:layout_marginTop="@dimen/navdrawer_user_image_top_margin"
@@ -40,7 +40,7 @@
     android:layout_marginBottom="@dimen/content_padding"
     android:layout_marginLeft="@dimen/keyline_1"
     android:layout_marginRight="@dimen/keyline_1"
-    android:textColor="@color/white"
+    android:textColor="?android:textColorPrimaryInverse"
     android:text="@string/login_register"/>
 
   <TextView
@@ -48,10 +48,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_above="@id/navdrawer_user_name"
-    android:layout_marginEnd="@dimen/keyline_1"
     android:layout_marginLeft="@dimen/keyline_1"
     android:layout_marginRight="@dimen/keyline_1"
-    android:layout_marginStart="@dimen/keyline_1"
     android:fontFamily="sans-serif-medium"
     android:text="@string/welcome"
     android:textColor="?android:textColorPrimaryInverse"/>

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -37,11 +37,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
-    android:layout_marginBottom="@dimen/keyline_1"
-    android:layout_marginEnd="@dimen/keyline_1"
+    android:layout_marginBottom="@dimen/content_padding"
     android:layout_marginLeft="@dimen/keyline_1"
     android:layout_marginRight="@dimen/keyline_1"
-    android:layout_marginStart="@dimen/keyline_1"
     android:textColor="@color/white"
     android:text="@string/login_register"/>
 
@@ -56,6 +54,6 @@
     android:layout_marginStart="@dimen/keyline_1"
     android:fontFamily="sans-serif-medium"
     android:text="@string/welcome"
-    android:textColor="@color/white"/>
+    android:textColor="?android:textColorPrimaryInverse"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="@dimen/navdrawer_image_height"
   android:orientation="vertical">
@@ -10,19 +11,51 @@
     android:layout_height="@dimen/navdrawer_image_height"
     android:contentDescription="@string/cd_navdrawer_image"
     android:scaleType="centerCrop"
-    android:src="@drawable/ic_logo_wide" />
+    tools:src="@drawable/ic_logo_wide" />
+
+  <View
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:alpha="0.6"
+    android:background="?attr/colorPrimary" />
 
   <ImageView
     android:id="@+id/navdrawer_user_picture"
     android:layout_width="@dimen/navdrawer_user_picture_size"
     android:layout_height="@dimen/navdrawer_user_picture_size"
-    android:layout_alignParentBottom="true"
     android:layout_alignParentLeft="true"
     android:layout_alignParentStart="true"
     android:layout_marginBottom="@dimen/keyline_1"
     android:layout_marginLeft="@dimen/keyline_1"
     android:layout_marginStart="@dimen/keyline_1"
+    android:layout_marginTop="@dimen/navdrawer_user_image_top_margin"
     android:contentDescription="@string/cd_navdrawer_user_picture"
-    android:scaleType="centerCrop" />
+    android:scaleType="centerCrop"/>
+
+  <TextView
+    android:id="@+id/navdrawer_user_name"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true"
+    android:layout_marginBottom="@dimen/keyline_1"
+    android:layout_marginEnd="@dimen/keyline_1"
+    android:layout_marginLeft="@dimen/keyline_1"
+    android:layout_marginRight="@dimen/keyline_1"
+    android:layout_marginStart="@dimen/keyline_1"
+    android:textColor="@color/white"
+    android:text="@string/login_register"/>
+
+  <TextView
+    android:id="@+id/welcome"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_above="@id/navdrawer_user_name"
+    android:layout_marginEnd="@dimen/keyline_1"
+    android:layout_marginLeft="@dimen/keyline_1"
+    android:layout_marginRight="@dimen/keyline_1"
+    android:layout_marginStart="@dimen/keyline_1"
+    android:fontFamily="sans-serif-medium"
+    android:text="@string/drawer_welcome"
+    android:textColor="@color/white"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -55,7 +55,7 @@
     android:layout_marginRight="@dimen/keyline_1"
     android:layout_marginStart="@dimen/keyline_1"
     android:fontFamily="sans-serif-medium"
-    android:text="@string/drawer_welcome"
+    android:text="@string/welcome"
     android:textColor="@color/white"/>
 
 </RelativeLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">لا يمكن تحليل \"معرف المنظم\": %1$s</string>
   <string name="cached_content">أنت غير متصل حاليا. وإليك بعض المحتوى المخزن مؤقتاً.</string>
   <string name="offline_alert">أنت غير متصل حاليا.</string>
-  <string name="welcome">مرحبا.</string>
+  <string name="welcome">مرحبا</string>
   <string name="choose_home_gdg">اختر المجموعة المنتمي إليها</string>
   <string name="signin_with_google">تسجيل الدخول باستخدام جوجل</string>
   <string name="confirm">تأكيد</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -181,4 +181,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -139,7 +139,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">Vítej</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -168,4 +168,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Nepodařilo se rozparsovat ID orga: %1$s</string>
   <string name="cached_content">Nyní jsi off-line. Tady máš nějaký nacachovaný obsah.</string>
   <string name="offline_alert">Jsi off-line.</string>
-  <string name="welcome">Vítej.</string>
+  <string name="welcome">Vítej</string>
   <string name="choose_home_gdg">Nastav si svoje domovské GDG</string>
   <string name="signin_with_google">Přihlásit se přes Google</string>
   <string name="confirm">Potvrdit</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Konnte Organizer Id: %1$s nicht parsen</string>
   <string name="cached_content">Du bist gerade offline. Hier ist eine ältere Version.</string>
   <string name="offline_alert">Du bist gerade offline.</string>
-  <string name="welcome">Willkommen.</string>
+  <string name="welcome">Willkommen</string>
   <string name="choose_home_gdg">Wähle deine Heimat-GDG</string>
   <string name="signin_with_google">Mit Google anmelden</string>
   <string name="confirm">Bestätigen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">No se pudo obtener el ID del Organizador: %1$s</string>
   <string name="cached_content">Te encuentras actualmente sin conexión. Aquí tienes contenido guardado.</string>
   <string name="offline_alert">Actualmente te encuentras sin conexión.</string>
-  <string name="welcome">Bienvenido(a)</string>
+  <string name="welcome">Bienvenida(o)</string>
   <string name="choose_home_gdg">Elige tu GDG</string>
   <string name="signin_with_google">Iniciar con Google+</string>
   <string name="confirm">Confirmar</string>
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">No se pudo obtener el ID del Organizador: %1$s</string>
   <string name="cached_content">Te encuentras actualmente sin conexión. Aquí tienes contenido guardado.</string>
   <string name="offline_alert">Actualmente te encuentras sin conexión.</string>
-  <string name="welcome">Bienvenido(a).</string>
+  <string name="welcome">Bienvenido(a)</string>
   <string name="choose_home_gdg">Elige tu GDG</string>
   <string name="signin_with_google">Iniciar con Google+</string>
   <string name="confirm">Confirmar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Impossible d\'analyser l\'identifiant d\'organisateur : %1$s</string>
   <string name="cached_content">Vous êtes actuellement déconnecté. Voici le contenu mis en cache.</string>
   <string name="offline_alert">Vous êtes actuellement déconnecté.</string>
-  <string name="welcome">Bienvenue.</string>
+  <string name="welcome">Bienvenue</string>
   <string name="choose_home_gdg">Choisissez votre GDG</string>
   <string name="signin_with_google">Identifiez-vous avec Google</string>
   <string name="confirm">Confirmez</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -169,4 +169,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">आयोजक संख्या %1$s समझी नहीं जा सकी </string>
   <string name="cached_content">इस समय आप ऑफलाइन हैं ।  पहले से राखी हुई कुछ सूचना इस प्रकार है :</string>
   <string name="offline_alert">इस समय आप ऑफलाइन हैं ।</string>
-  <string name="welcome">स्वागत है !</string>
+  <string name="welcome">स्वागत है</string>
   <string name="choose_home_gdg">अपना जी डी जी चयन करें</string>
   <string name="signin_with_google">अपने गूगल अकाउंट के साथ जुड़ें</string>
   <string name="confirm">पुष्टि करें</string>
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Nem sikerült értelmezni szervező azonosítót: %1$s</string>
   <string name="cached_content">Jelenleg nincs net kapcsolat. Íme néhány elmentett tartalom.</string>
   <string name="offline_alert">Jelenleg nincs net kapcsolat.</string>
-  <string name="welcome">Üdvözlet.</string>
+  <string name="welcome">Üdvözlet</string>
   <string name="choose_home_gdg">Válaszd ki az otthoni GDG-det</string>
   <string name="signin_with_google">Bejelentkezés Google-lel</string>
   <string name="confirm">Jóváhagy</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Այս կազմակերպիչի տվյալները բացակայում են՝ %1$s</string>
   <string name="cached_content">Դուք հիմա անցանց եք: Ցուցադրվող բովանդակությունը քեշից է:</string>
   <string name="offline_alert">Դուք անցանց եք:</string>
-  <string name="welcome">Բարի գալուստ:</string>
+  <string name="welcome">Բարի գալուստ</string>
   <string name="choose_home_gdg">Ընտրեք ձեր GDG-ն</string>
   <string name="signin_with_google">Մուտք գործել Google-ով</string>
   <string name="confirm">Հաստատել</string>
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Impossibile analizzare Organizer Id: %1$s</string>
   <string name="cached_content">Sei attualmente offline. Ecco alcuni contenuti nella cache.</string>
   <string name="offline_alert">Sei attualmente offline.</string>
-  <string name="welcome">Benvenuto.</string>
+  <string name="welcome">Benvenuto</string>
   <string name="choose_home_gdg">Scegli il GDG della tua città</string>
   <string name="signin_with_google">Accedi con Google</string>
   <string name="confirm">Conferma</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -161,4 +161,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -131,7 +131,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">반갑습니다</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -160,4 +160,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">운영자 Id를 분석할 수 없습니다: %1$s</string>
   <string name="cached_content">현재 오프라인 상태입니다. 이전에 가져왔던 정보가 보여집니다.</string>
   <string name="offline_alert">현재 오프라인 상태입니다.</string>
-  <string name="welcome">반갑습니다.</string>
+  <string name="welcome">반갑습니다</string>
   <string name="choose_home_gdg">기본 GDG 선택하세요.</string>
   <string name="signin_with_google">Google로 로그인</string>
   <string name="confirm">확인</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Nepavyko paimti Organizatoriaus Id iš: %1$s</string>
   <string name="cached_content">Nėra ryšio. Rodomas ankstesnė informacija.</string>
   <string name="offline_alert">Nėra ryšio.</string>
-  <string name="welcome">labàdienà</string>
+  <string name="welcome">Labàdienà</string>
   <string name="choose_home_gdg">Pasirink artimiausią GDG</string>
   <string name="signin_with_google">Prisijungti su Google</string>
   <string name="confirm">Gerai</string>
@@ -139,7 +139,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">Labàdienà</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -168,4 +168,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Organisatoren Id: %1$s kan niet geparset worden</string>
   <string name="cached_content">Jij bent momenteel offline. Hier is een beetje opgeslagen inhoud.</string>
   <string name="offline_alert">Jij bent momenteel offline.</string>
-  <string name="welcome">Welkom.</string>
+  <string name="welcome">Welkom</string>
   <string name="choose_home_gdg">Kies je lokale GDG</string>
   <string name="signin_with_google">Inloggen met Google</string>
   <string name="confirm">Bevestigen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -135,7 +135,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">Welkom</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Nieprawidłowy identyfikator organizatora: %1$s</string>
   <string name="cached_content">Brak połączenia. Dostępne są pobrane wcześniej informacje.</string>
   <string name="offline_alert">Brak połączenia.</string>
-  <string name="welcome">Witaj.</string>
+  <string name="welcome">Witaj</string>
   <string name="choose_home_gdg">Wybierz swój podstawowy GDG</string>
   <string name="signin_with_google">Zaloguj się poprzez Google</string>
   <string name="confirm">Potwierdź</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Nieprawidłowy identyfikator organizatora: %1$s</string>
   <string name="cached_content">Brak połączenia. Dostępne są pobrane wcześniej informacje.</string>
   <string name="offline_alert">Brak połączenia.</string>
-  <string name="welcome">Witaj</string>
+  <string name="welcome">Witamy</string>
   <string name="choose_home_gdg">Wybierz swój podstawowy GDG</string>
   <string name="signin_with_google">Zaloguj się poprzez Google</string>
   <string name="confirm">Potwierdź</string>
@@ -168,4 +168,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Não foi possível analisar o Id do organizador: %1$s</string>
   <string name="cached_content">Você está atualmente offline. Segue o conteúdo do cache.</string>
   <string name="offline_alert">Você está offline.</string>
-  <string name="welcome">Bem-vindo</string>
+  <string name="welcome">Seja bem-vindo(a)</string>
   <string name="choose_home_gdg">Escolha o seu GDG de origem</string>
   <string name="signin_with_google">Faça sign-in com o Google</string>
   <string name="confirm">Confirme</string>
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Não foi possível analisar o Id do organizador: %1$s</string>
   <string name="cached_content">Você está atualmente offline. Segue o conteúdo do cache.</string>
   <string name="offline_alert">Você está offline.</string>
-  <string name="welcome">Bem-vindo.</string>
+  <string name="welcome">Bem-vindo</string>
   <string name="choose_home_gdg">Escolha o seu GDG de origem</string>
   <string name="signin_with_google">Faça sign-in com o Google</string>
   <string name="confirm">Confirme</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Could not parse Organizer Id: %1$s</string>
   <string name="cached_content">Você está atualmente off-line. Aqui está algum conteúdo em cache.</string>
   <string name="offline_alert">Você está atualmente off-line.</string>
-  <string name="welcome">Bem-vindo.</string>
+  <string name="welcome">Bem-vindo</string>
   <string name="choose_home_gdg">Escolha sua casa GDG</string>
   <string name="signin_with_google">Entrar com o Google</string>
   <string name="confirm">Confirmar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -23,19 +23,19 @@
   <string name="events">Eventos</string>
   <string name="add_to_calendar">Adicionar ao calendário</string>
   <string name="share_with_googleplus">Compartilhe com o Google +</string>
-  <string name="no_scheduled_events">No events scheduled\nwithin the next 30 days</string>
+  <string name="no_scheduled_events">Não existem eventos\nnos próximos 30 dias</string>
   <string name="organizers">Organizadores</string>
   <string name="resources">Links</string>
   <string name="fetch_events_failed">Não poderia trazer-próximos eventos</string>
   <string name="fetch_chapters_failed">Não posso buscar a lista de capítulo</string>
-  <string name="bogus_organizer">Could not parse Organizer Id: %1$s</string>
+  <string name="bogus_organizer">Não foi possível ler o id do Organizador: %1$s</string>
   <string name="cached_content">Você está atualmente off-line. Aqui está algum conteúdo em cache.</string>
   <string name="offline_alert">Você está atualmente off-line.</string>
   <string name="welcome">Bem-vindo</string>
   <string name="choose_home_gdg">Escolha sua casa GDG</string>
   <string name="signin_with_google">Entrar com o Google</string>
   <string name="confirm">Confirmar</string>
-  <string name="signin_description">The GDG App integrates with Google+ and other Google Services. To use these function we need you to be signed into Google.</string>
+  <string name="signin_description">A aplicação GDG faz integração com o Google+ e outros serviços Google. Para tirar proveito de todas as funcionalidades é necessário fazer o login com uma conta Google.</string>
   <string name="or">ou</string>
   <string name="skip">Pular Sign-In</string>
   <string name="youtube_init_failed">Player do YouTube não pôde ser inicializado.</string>
@@ -50,31 +50,31 @@
     <item quantity="other">%d minutes ago</item>
   </plurals>
   <plurals name="hours_ago">
-    <item quantity="one">1 hour ago</item>
-    <item quantity="other">%d hours ago</item>
+    <item quantity="one">1 hora atrás</item>
+    <item quantity="other">%d horas atrás</item>
   </plurals>
   <plurals name="days_ago">
     <item quantity="one">1 dia atrás</item>
     <item quantity="other">%d days ago</item>
   </plurals>
-  <string name="contributors">The GDG app is a community effort and open sourced. The following people contributed to the app:</string>
+  <string name="contributors">A aplicação GDG provém de um esforço comunitário e open sourced. Foram as seguintes pessoas que contribuíram na a sua programação:</string>
   <string name="get_involved">Se envolva!</string>
-  <string name="get_involved_text">The GDG app is a community effort and open sourced. Everyone is welcome to participate and improve this app.\n\nJust head over to GitHub and checkout our code.\n\nhttps://github.com/gdg-x</string>
+  <string name="get_involved_text">A aplicação GDG provém de um esforço comunitário e open sourced. Toda a gente é bem vinda de participar e melhorar a aplicação.\n\nVisite o nosso repositório no GitHub e vê o código.\n\nhttps://github.com/gdg-x</string>
   <string name="about_license">© 2013 The GDG Frisbee Project\nAll Rights reserved.\n\nLicensed under the terms\nof the Apache 2.0 License</string>
-  <string name="past_event">PAST</string>
-  <string name="upcoming_widget">GDG - Upcoming Event</string>
+  <string name="past_event">ANTIGO</string>
+  <string name="upcoming_widget">GDG - Próximo Evento</string>
   <string name="global">Global</string>
   <string name="pulse">GDG Pulse</string>
   <string name="pulse_events">Eventos</string>
   <string name="pulse_attendees">Participantes</string>
-  <string name="pulse_circlers">Chapter Circlers</string>
+  <string name="pulse_circlers">Circulos dos Capítulos</string>
   <string name="home_gdg">Home GDG</string>
-  <string name="home_gdg_with_city">Home GDG: %1$s</string>
+  <string name="home_gdg_with_city">Página Principal GDG: %1$s</string>
   <string name="home_gdg_summary">Selecione seu primário GDG</string>
-  <string name="remove_trailing_spaces">Please remove trailing spaces</string>
+  <string name="remove_trailing_spaces">Por favor remova os espaços antes e depois do texto</string>
   <string name="analytics">Analytics</string>
-  <string name="analytics_summary_on">The app currently transmits anonymous usage data which allows us to improve the app</string>
-  <string name="analytics_summary_off">The app currently does not transmit any anonymous usage data</string>
+  <string name="analytics_summary_on">Esta aplicação envia actualmente informação anónima do uso que nos ajuda a melhorar</string>
+  <string name="analytics_summary_off">Esta aplicação não envia informação anónima do uso</string>
   <string name="gcm">Notificações de nuvem</string>
   <string name="gcm_summary_on">O app atualmente recebe e processa a notificação de nuvem GDG</string>
   <string name="gcm_summary_off">O app atualmente não recebe notificação de nuvem GDG</string>
@@ -117,7 +117,7 @@
   <string name="share">Compartilhar</string>
   <string name="open_event_site">Ver página de eventos</string>
   <string name="arrow_tagged">Seus organizadores marcados</string>
-  <string name="get_involved_translation_text">Se você gosta de contribuir para a localização do app, ou seja, traduzir para uma língua nova, ou melhorar os existentes, por favor, vá para a página: \n\n https://crowdin.com/project/gdgx-frisbee</string>
+  <string name="get_involved_translation_text">Se você gosta de contribuir para a localização do app, ou seja, traduzir para uma língua nova, ou melhorar os existentes, por favor, vá para a página:\n\nhttps://crowdin.com/project/gdgx-frisbee</string>
   <string name="about_about">Sobre</string>
   <string name="about_contributors">Contribuidores</string>
   <string name="about_translators">Tradutores</string>
@@ -135,7 +135,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">Bem-vindo</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -139,7 +139,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">Добро пожаловать</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -168,4 +168,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Не удаётся проанализировать Organizer Id: %1$s</string>
   <string name="cached_content">В настоящее время ты офлайн. Используется сохранённое в кэше содержание.</string>
   <string name="offline_alert">В настоящее время ты офлайн.</string>
-  <string name="welcome">Добро пожаловать.</string>
+  <string name="welcome">Добро пожаловать</string>
   <string name="choose_home_gdg">Выбери свой локальный GDG</string>
   <string name="signin_with_google">Войди с Google</string>
   <string name="confirm">Подтвердить</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -139,7 +139,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">Vitajte</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -168,4 +168,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Nebolo možné načítať organizátora Id: %1$s</string>
   <string name="cached_content">Ste offline, zobrazuje sa nacachovaný obsah.</string>
   <string name="offline_alert">Ste offline.</string>
-  <string name="welcome">Vitajte.</string>
+  <string name="welcome">Vitajte</string>
   <string name="choose_home_gdg">Vyberte svoje domáce GDG</string>
   <string name="signin_with_google">Prihláste sa na Google účet</string>
   <string name="confirm">Potvrdiť</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -131,7 +131,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">ยินดีต้อนรับ</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -160,4 +160,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -164,4 +164,5 @@
   <string name="cd_invitation_sender_profile_image">Davetiye gönderen profil resmi</string>
   <string name="invite_congrats">Yaşasın! Sizi davet eden\n%s</string>
   <string name="friend">bir arkadaş</string>
+  <string name="login_register">Giriş yap/Kayıt ol</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -191,4 +191,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -32,7 +32,7 @@
   <string name="cached_content">На даний момент ви не в мережі. Використовуються дані з кешу.
     </string>
   <string name="offline_alert">На даний момент ви не в мережі.</string>
-  <string name="welcome">Ласкаво просимо.</string>
+  <string name="welcome">Ласкаво просимо</string>
   <string name="choose_home_gdg">Виберіть GDG поряд з вами</string>
   <string name="signin_with_google">Вхід з Google</string>
   <string name="confirm">Підтвердити</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">无法解析组织 Id：%1$s</string>
   <string name="cached_content">您目前为离线状态，这里是缓存內容</string>
   <string name="offline_alert">您目前为离线状态</string>
-  <string name="welcome">欢迎光临</string>
+  <string name="welcome">欢迎</string>
   <string name="choose_home_gdg">选择您所在地 GDG</string>
   <string name="signin_with_google">Google 登录</string>
   <string name="confirm">确定</string>
@@ -160,4 +160,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -131,7 +131,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">歡迎光臨</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -160,4 +160,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -131,7 +131,7 @@
   <string name="feedback_send">Send</string>
   <string name="feedback_sending">Sending&#8230;</string>
   <string name="for_leads">For Leads</string>
-  <string name="leads_welcome_title">Welcome</string>
+  <string name="leads_welcome_title">歡迎光臨</string>
   <string name="leads_welcome">As a GDG lead, you have access to these organizer-only resources!</string>
   <string name="leads_resources_title">GDG Resources</string>
   <string name="leads_resources">You can find important GDG Resources in this Google Drive folder. Tap to browse slide decks, guides, graphics, code labs, and more.</string>
@@ -160,4 +160,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -24,5 +24,6 @@
 
   <dimen name="list_item_avatar">46dp</dimen>
   <dimen name="organizer_icon_size">32dp</dimen>
+  <dimen name="navdrawer_user_image_top_margin">32dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
   <string name="bogus_organizer">Could not parse Organizer Id: %1$s</string>
   <string name="cached_content">You\'re currently offline. Here\'s some cached content.</string>
   <string name="offline_alert">You\'re currently offline.</string>
-  <string name="welcome">Welcome.</string>
+  <string name="welcome">Welcome</string>
   <string name="drawer_welcome">Welcome</string>
   <string name="choose_home_gdg">Choose your home GDG</string>
   <string name="signin_with_google">Sign-in with Google</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">You\'re currently offline. Here\'s some cached content.</string>
   <string name="offline_alert">You\'re currently offline.</string>
   <string name="welcome">Welcome.</string>
+  <string name="drawer_welcome">Welcome</string>
   <string name="choose_home_gdg">Choose your home GDG</string>
   <string name="signin_with_google">Sign-in with Google</string>
   <string name="confirm">Confirm</string>
@@ -173,4 +174,5 @@
   <string name="cd_invitation_sender_profile_image">Invitation sender profile image</string>
   <string name="invite_congrats">Yey! You\'re invited by\n%s</string>
   <string name="friend">a friend</string>
+  <string name="login_register">Login/Register</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,7 +32,6 @@
   <string name="cached_content">You\'re currently offline. Here\'s some cached content.</string>
   <string name="offline_alert">You\'re currently offline.</string>
   <string name="welcome">Welcome</string>
-  <string name="drawer_welcome">Welcome</string>
   <string name="choose_home_gdg">Choose your home GDG</string>
   <string name="signin_with_google">Sign-in with Google</string>
   <string name="confirm">Confirm</string>


### PR DESCRIPTION
This PR adds the login option to the nav drawer header. 
After login, the user's G+ display name and profile picture is displayed on the header. A circular transform is applied to the profile picture to maintain consistency with other Material Design apps. The header has a 0.6 alpha primaryColor filter applied, so it has the color tint of the selected activity.

Screencast:
https://vimeo.com/186100986

Fixes #526 