### PR TITLE
Load organizers one by one to avoid rate limit problems

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
+++ b/app/src/main/java/org/gdg/frisbee/android/cache/ModelCache.java
@@ -137,7 +137,7 @@ public final class ModelCache {
     }
 
     @Nullable
-    public Object get(String url, boolean checkExpiration) {
+    public <T> T get(String url, boolean checkExpiration) {
         Timber.d("get(%s)", url);
         CacheItem result;
 
@@ -150,7 +150,8 @@ public final class ModelCache {
         }
 
         if (result != null) {
-            return result.getValue();
+            //noinspection unchecked
+            return (T) result.getValue();
         } else {
             return null;
         }
@@ -198,6 +199,7 @@ public final class ModelCache {
         return result;
     }
 
+    @Nullable
     private CacheItem getFromMemoryCache(final String url, boolean checkExpiration) {
         CacheItem result = null;
 

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -131,6 +131,7 @@ public class InfoFragment extends BaseFragment implements OrganizerLoader.Listen
 
                 @Override
                 public void failure(Throwable error) {
+                    showError(R.string.server_error);
                     setIsLoading(false);
                 }
 

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -16,10 +16,14 @@
 
 package org.gdg.frisbee.android.chapter;
 
+import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.AsyncTaskLoader;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.Loader;
 import android.text.Html;
 import android.text.Spanned;
 import android.text.SpannedString;
@@ -47,30 +51,28 @@ import org.gdg.frisbee.android.utils.Utils;
 import org.gdg.frisbee.android.view.BitmapBorderTransformation;
 import org.joda.time.DateTime;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.BindView;
+import retrofit2.Response;
 import timber.log.Timber;
 
-public class InfoFragment extends BaseFragment {
-
+public class InfoFragment extends BaseFragment implements LoaderManager.LoaderCallbacks<List<Person>> {
+    public static final String ORGANIZER_IDS = "organizerIds";
     @BindView(R.id.about)
     TextView mAbout;
-
     @BindView(R.id.tagline)
     TextView mTagline;
-
     @BindView(R.id.organizer_box)
     LinearLayout mOrganizerBox;
-
     @BindView(R.id.resources_box)
     LinearLayout mResourcesBox;
-
     @BindView(R.id.loading)
     DelayedProgressBar mProgressContainer;
-
     @BindView(R.id.container)
     ScrollView mContainer;
 
@@ -78,7 +80,6 @@ public class InfoFragment extends BaseFragment {
 
     private LayoutInflater mInflater;
     private String chapterPlusId;
-
 
     public static InfoFragment newInstance(String plusId) {
         InfoFragment fragment = new InfoFragment();
@@ -102,42 +103,51 @@ public class InfoFragment extends BaseFragment {
             online, new ModelCache.CacheListener() {
                 @Override
                 public void onGet(Object item) {
-                    updateUIFrom((Person) item, online);
+                    updateUIFrom((Person) item);
                 }
 
                 @Override
                 public void onNotFound(String key) {
-                    if (online) {
-                        App.getInstance().getPlusApi().getPerson(chapterPlusId).enqueue(
-                            new Callback<Person>() {
-                                @Override
-                                public void success(Person chapter) {
-                                    putPersonInCache(chapterPlusId, chapter);
-                                    updateUIFrom(chapter, true);
-                                }
-
-                                @Override
-                                public void failure(Throwable error) {
-                                    setIsLoading(false);
-                                }
-
-                                @Override
-                                public void networkFailure(Throwable error) {
-                                    setIsLoading(false);
-                                }
-                            });
-                    } else {
-                        showError(R.string.offline_alert);
-                        setIsLoading(false);
-                    }
+                    loadChapterFromNetwork();
                 }
             });
     }
 
-    void updateUIFrom(Person chapter, boolean online) {
+    void loadChapterFromNetwork() {
+        App.getInstance().getPlusApi().getPerson(chapterPlusId).enqueue(
+            new Callback<Person>() {
+                @Override
+                public void success(Person chapter) {
+                    putChapterInCache(chapterPlusId, chapter);
+                    updateUIFrom(chapter);
+                }
+
+                @Override
+                public void failure(Throwable error) {
+                    setIsLoading(false);
+                }
+
+                @Override
+                public void networkFailure(Throwable error) {
+                    showError(R.string.offline_alert);
+                    setIsLoading(false);
+                }
+
+                private void putChapterInCache(String plusId, Person person) {
+                    App.getInstance().getModelCache().putAsync(
+                        ModelCache.KEY_PERSON + plusId,
+                        person,
+                        DateTime.now().plusDays(1),
+                        null
+                    );
+                }
+            });
+    }
+
+    void updateUIFrom(Person chapter) {
         if (getActivity() != null) {
             updateChapterUIFrom(chapter);
-            addOrganizers(chapter, online);
+            addOrganizers(chapter);
         }
     }
 
@@ -146,12 +156,12 @@ public class InfoFragment extends BaseFragment {
             mTagline.setText(chapter.getTagline());
         }
         if (mAbout != null) {
-            mAbout.setText(getAboutText(chapter));
+            mAbout.setText(createAboutText(chapter));
             mAbout.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 
-    private Spanned getAboutText(Person person) {
+    private Spanned createAboutText(Person person) {
         String aboutText = person.getAboutMe();
         if (aboutText == null) {
             return SpannedString.valueOf("");
@@ -159,28 +169,31 @@ public class InfoFragment extends BaseFragment {
         return Html.fromHtml(aboutText);
     }
 
-    private void addOrganizers(Person cachedChapter, boolean online) {
+    private void addOrganizers(Person cachedChapter) {
+        setIsLoading(false);
         List<Urls> urls = cachedChapter.getUrls();
-        if (urls != null) {
-            for (int chapterIndex = 0, size = urls.size(); chapterIndex < size; chapterIndex++) {
-                Urls url = urls.get(chapterIndex);
-                if (isNonCommunityPlusUrl(url)) {
-                    String org = url.getValue();
-                    try {
-                        String id = getGPlusIdFromPersonUrl(url);
-                        addOrganizerAsync(id, online);
-                    } catch (Exception ex) {
-                        if (isContextValid()) {
-                            addUrlToUI(url);
-                            Timber.w(ex, "Could not parse organizer: %s", org);
-                        }
+        if (urls == null) {
+            return;
+        }
+        ArrayList<String> organizerIds = new ArrayList<>();
+        for (Urls url : urls) {
+            if (isNonCommunityPlusUrl(url)) {
+                String org = url.getValue();
+                try {
+                    organizerIds.add(getGPlusIdFromPersonUrl(url));
+                } catch (Exception ex) {
+                    if (isContextValid()) {
+                        addUrlToUI(url);
+                        Timber.w(ex, "Could not parse organizer: %s", org);
                     }
-                } else {
-                    addUrlToUI(url);
                 }
+            } else {
+                addUrlToUI(url);
             }
         }
-        setIsLoading(false);
+        Bundle args = new Bundle();
+        args.putStringArrayList(ORGANIZER_IDS, organizerIds);
+        getLoaderManager().initLoader(0, args, this).forceLoad();
     }
 
     private boolean isNonCommunityPlusUrl(Urls url) {
@@ -195,80 +208,51 @@ public class InfoFragment extends BaseFragment {
         mResourcesBox.addView(tv);
     }
 
-    private void addOrganizerAsync(final String gplusId, final boolean online) {
-        App.getInstance().getModelCache().getAsync(
-            ModelCache.KEY_PERSON + gplusId,
-            online,
-            new ModelCache.CacheListener() {
-                @Override
-                public void onGet(Object item) {
-                    addOrganizerToUI((Person) item);
-                }
+    @Override
+    public Loader<List<Person>> onCreateLoader(int id, final Bundle args) {
+        return new OrganizerLoader(getContext(), args.getStringArrayList(ORGANIZER_IDS));
+    }
 
-                @Override
-                public void onNotFound(String key) {
-                    if (online) {
-                        App.getInstance().getPlusApi().getPerson(gplusId).enqueue(new Callback<Person>() {
-                            @Override
-                            public void success(Person organizer) {
-                                putPersonInCache(gplusId, organizer);
-                                addOrganizerToUI(organizer);
-                            }
-
-                            @Override
-                            public void failure(Throwable error) {
-                                addUnknownOrganizerToUI();
-                            }
-
-                            @Override
-                            public void networkFailure(Throwable error) {
-                                addUnknownOrganizerToUI();
-                            }
-                        });
-
-                    } else {
-                        addUnknownOrganizerToUI();
-                    }
-                }
+    @Override
+    public void onLoadFinished(Loader<List<Person>> loader, List<Person> organizers) {
+        for (Person organizer : organizers) {
+            if (organizer != null) {
+                addOrganizerToUI(organizer);
+            } else {
+                addUnknownOrganizerToUI();
             }
-        );
+        }
+    }
+
+    @Override
+    public void onLoaderReset(Loader<List<Person>> loader) {
+        // no-op
     }
 
     private void addOrganizerToUI(final Person organizer) {
-        if (organizer == null) {
-            addUnknownOrganizerToUI();
-            return;
-        }
-
         View v = createOrganizerView(organizer);
-        if (v != null) {
-            v.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    String url = organizer.getUrl();
-                    if (!TextUtils.isEmpty(url)) {
-                        startActivity(Utils.createExternalIntent(getActivity(), Uri.parse(url)));
-                    }
+        v.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                String url = organizer.getUrl();
+                if (!TextUtils.isEmpty(url)) {
+                    startActivity(Utils.createExternalIntent(getActivity(), Uri.parse(url)));
                 }
-            });
-            if (mOrganizerBox != null) {
-                mOrganizerBox.addView(v);
             }
+        });
+        if (mOrganizerBox != null) {
+            mOrganizerBox.addView(v);
         }
     }
 
-    @Nullable
-    private View createOrganizerView(Person person) {
-        if (!isContextValid()) {
-            return null;
-        }
+    private View createOrganizerView(Person organizer) {
         View convertView = mInflater.inflate(R.layout.list_organizer_item, (ViewGroup) getView(), false);
 
         ImageView picture = (ImageView) convertView.findViewById(R.id.icon);
 
-        if (person.getImage() != null) {
+        if (organizer.getImage() != null) {
             App.getInstance().getPicasso()
-                .load(person.getImage().getUrl())
+                .load(organizer.getImage().getUrl())
                 .transform(new BitmapBorderTransformation(0,
                     getResources().getDimensionPixelSize(R.dimen.organizer_icon_size) / 2,
                     ContextCompat.getColor(getContext(), R.color.white)))
@@ -277,7 +261,7 @@ public class InfoFragment extends BaseFragment {
         }
 
         TextView title = (TextView) convertView.findViewById(R.id.title);
-        title.setText(person.getDisplayName());
+        title.setText(organizer.getDisplayName());
 
         return convertView;
     }
@@ -298,15 +282,6 @@ public class InfoFragment extends BaseFragment {
         TextView title = (TextView) convertView.findViewById(R.id.title);
         title.setText(R.string.name_not_known);
         return convertView;
-    }
-
-    private void putPersonInCache(String plusId, Person person) {
-        App.getInstance().getModelCache().putAsync(
-            ModelCache.KEY_PERSON + plusId,
-            person,
-            DateTime.now().plusDays(1),
-            null
-        );
     }
 
     private String getGPlusIdFromPersonUrl(Urls personUrl) {
@@ -367,5 +342,54 @@ public class InfoFragment extends BaseFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflateView(inflater, R.layout.fragment_chapter_info, container);
+    }
+
+    private static class OrganizerLoader extends AsyncTaskLoader<List<Person>> {
+        private final boolean online;
+        private final ArrayList<String> organizerIds;
+
+        OrganizerLoader(Context context, ArrayList<String> organizerIds) {
+            super(context);
+            this.organizerIds = organizerIds;
+            online = Utils.isOnline(getContext());
+        }
+
+        @Override
+        public List<Person> loadInBackground() {
+            List<Person> organizers = new ArrayList<>(organizerIds.size());
+            for (String gplusId : organizerIds) {
+                organizers.add(loadOrganizer(gplusId));
+            }
+            return organizers;
+        }
+
+        @Nullable
+        private Person loadOrganizer(String gplusId) {
+            Person person = App.getInstance().getModelCache()
+                .get(ModelCache.KEY_PERSON + gplusId, online);
+            if (person != null) {
+                return person;
+            }
+            try {
+                Response<Person> response = App.getInstance().getPlusApi().
+                    getPerson(gplusId).execute();
+                if (response.isSuccessful()) {
+                    person = response.body();
+                    putPersonInCache(gplusId, person);
+                    return person;
+                }
+            } catch (IOException ignored) {
+            }
+            return null;
+        }
+
+        private void putPersonInCache(String plusId, Person person) {
+            App.getInstance().getModelCache().putAsync(
+                ModelCache.KEY_PERSON + plusId,
+                person,
+                DateTime.now().plusDays(1),
+                null
+            );
+        }
     }
 }

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/InfoFragment.java
@@ -169,12 +169,12 @@ public class InfoFragment extends BaseFragment implements OrganizerLoader.Listen
         }
     }
 
-    private Spanned createAboutText(Person person) {
+    private static CharSequence createAboutText(Person person) {
         String aboutText = person.getAboutMe();
         if (aboutText == null) {
             return SpannedString.valueOf("");
         }
-        return Html.fromHtml(aboutText);
+        return createHtmlFormatted(aboutText);
     }
 
     private void addOrganizers(Person cachedChapter) {
@@ -204,16 +204,21 @@ public class InfoFragment extends BaseFragment implements OrganizerLoader.Listen
         organizerLoader.execute(organizerIds.toArray(new String[organizerIds.size()]));
     }
 
-    private boolean isNonCommunityPlusUrl(Urls url) {
+    private static boolean isNonCommunityPlusUrl(Urls url) {
         return url.getValue().contains("plus.google.com/") && !url.getValue().contains("communities");
     }
 
     private void addUrlToUI(Urls url) {
         TextView tv = (TextView) mInflater
             .inflate(R.layout.list_resource_item, (ViewGroup) getView(), false);
-        tv.setText(Html.fromHtml("<a href='" + url.getValue() + "'>" + url.getLabel() + "</a>"));
+        tv.setText(createHtmlFormatted("<a href='" + url.getValue() + "'>" + url.getLabel() + "</a>"));
         tv.setMovementMethod(LinkMovementMethod.getInstance());
         mResourcesBox.addView(tv);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Spanned createHtmlFormatted(String source) {
+        return Html.fromHtml(source);
     }
 
     @Override

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/OrganizerLoader.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/OrganizerLoader.java
@@ -63,7 +63,7 @@ class OrganizerLoader extends AsyncTask<String, Person, Void> {
         return null;
     }
 
-    private void putPersonInCache(String plusId, Person person) {
+    private static void putPersonInCache(String plusId, Person person) {
         App.getInstance().getModelCache().putAsync(
             ModelCache.KEY_PERSON + plusId,
             person,

--- a/app/src/main/java/org/gdg/frisbee/android/chapter/OrganizerLoader.java
+++ b/app/src/main/java/org/gdg/frisbee/android/chapter/OrganizerLoader.java
@@ -1,0 +1,84 @@
+package org.gdg.frisbee.android.chapter;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.support.annotation.Nullable;
+
+import org.gdg.frisbee.android.api.model.plus.Person;
+import org.gdg.frisbee.android.app.App;
+import org.gdg.frisbee.android.cache.ModelCache;
+import org.gdg.frisbee.android.utils.Utils;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+
+import retrofit2.Response;
+
+class OrganizerLoader extends AsyncTask<String, Person, Void> {
+    private final boolean online;
+    private Listener listener;
+
+    OrganizerLoader(Context context) {
+        online = Utils.isOnline(context);
+    }
+
+    @Override
+    protected Void doInBackground(String... organizerIds) {
+        for (String gplusId : organizerIds) {
+            publishProgress(loadOrganizer(gplusId));
+        }
+        return null;
+    }
+
+    @Override
+    protected void onProgressUpdate(Person... values) {
+        if (listener == null) {
+            return;
+        }
+        Person organizer = values[0];
+        if (organizer != null) {
+            listener.onOrganizerLoaded(organizer);
+        } else {
+            listener.onUnknownOrganizerLoaded();
+        }
+    }
+
+    @Nullable
+    private Person loadOrganizer(String gplusId) {
+        Person person = App.getInstance().getModelCache()
+            .get(ModelCache.KEY_PERSON + gplusId, online);
+        if (person != null) {
+            return person;
+        }
+        try {
+            Response<Person> response = App.getInstance().getPlusApi().
+                getPerson(gplusId).execute();
+            if (response.isSuccessful()) {
+                person = response.body();
+                putPersonInCache(gplusId, person);
+                return person;
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    private void putPersonInCache(String plusId, Person person) {
+        App.getInstance().getModelCache().putAsync(
+            ModelCache.KEY_PERSON + plusId,
+            person,
+            DateTime.now().plusDays(1),
+            null
+        );
+    }
+
+    public void setListener(@Nullable Listener listener) {
+        this.listener = listener;
+    }
+
+    interface Listener {
+        void onOrganizerLoaded(Person organizer);
+
+        void onUnknownOrganizerLoaded();
+    }
+}

--- a/app/src/main/res/layout/list_organizer_item.xml
+++ b/app/src/main/res/layout/list_organizer_item.xml
@@ -20,6 +20,7 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:orientation="horizontal"
+  android:background="?selectableItemBackground"
   android:padding="8dip">
 
   <ImageView


### PR DESCRIPTION
This PR includes a solution that will _hopefully_ make rate limiting 403 API errors lot less. 

I guess the real solution to that would be to bound ou API key to our app signature. When we do that, Google+ API will give us option for more API calls. 

But I also realized that we are loading all the organizers at once. This PR proposes a very simple AsyncTask to load organizers one by one. It will load them synchronously one by one and let the UI know about organizers one by one. 

Throughout the code in `InfoFragment`, I also did lots of refactoring to keep indentation sane. 

Fixes #693