### PR TITLE
Force sign in after app update

### DIFF
--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -147,6 +147,8 @@ public abstract class GdgActivity extends TrackableActivity implements
             GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(data);
             if (result.isSuccess()) {
                 onSuccessfulSignIn(result.getSignInAccount());
+            } else {
+                PrefUtils.setSignedOut(this);
             }
         }
     }

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
+import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
@@ -108,6 +109,7 @@ public abstract class GdgActivity extends TrackableActivity implements
      *
      * @return {@link GoogleApiClient} without connecting. {@code connect()} must be called afterwards.
      */
+    @CheckResult
     protected GoogleApiClient createGoogleApiClient() {
         return GoogleApiClientFactory.createWith(this);
     }
@@ -121,7 +123,7 @@ public abstract class GdgActivity extends TrackableActivity implements
         mGoogleApiClient.disconnect();
     }
 
-    protected void requestSignIn() {
+    protected final void requestSignIn() {
         if (signInClient == null) {
             signInClient = GoogleApiClientFactory.createForSignIn(this, this);
         }

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgActivity.java
@@ -19,8 +19,10 @@ package org.gdg.frisbee.android.common;
 
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
+import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
@@ -31,15 +33,20 @@ import android.widget.Toast;
 
 import com.google.android.gms.appindexing.Action;
 import com.google.android.gms.appindexing.AppIndex;
+import com.google.android.gms.auth.api.Auth;
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.auth.api.signin.GoogleSignInResult;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.common.api.ResultCallbacks;
 import com.google.android.gms.common.api.Status;
 
 import org.gdg.frisbee.android.R;
 import org.gdg.frisbee.android.app.GoogleApiClientFactory;
+import org.gdg.frisbee.android.utils.PlusUtils;
 import org.gdg.frisbee.android.utils.PrefUtils;
 import org.gdg.frisbee.android.utils.RecentTasksStyler;
 import org.gdg.frisbee.android.view.ColoredSnackBar;
@@ -51,13 +58,14 @@ import timber.log.Timber;
 public abstract class GdgActivity extends TrackableActivity implements
     GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
 
+    private static final int RC_SIGN_IN = 101;
+
     @Nullable
     @BindView(R.id.content_frame)
     FrameLayout mContentLayout;
 
-    // GoogleApiClient wraps our service connection to Google Play services and
-    // provides access to the users sign in state and Google's APIs.
     private GoogleApiClient mGoogleApiClient;
+    private GoogleApiClient signInClient;
 
     private Toolbar mActionBarToolbar;
 
@@ -90,6 +98,9 @@ public abstract class GdgActivity extends TrackableActivity implements
         super.onStart();
 
         mGoogleApiClient.connect();
+        if (PrefUtils.isSignedIn(this) && PlusUtils.getCurrentAccount(this) == null) {
+            requestSignIn();
+        }
     }
 
     /**
@@ -108,6 +119,46 @@ public abstract class GdgActivity extends TrackableActivity implements
         mGoogleApiClient.unregisterConnectionCallbacks(this);
         mGoogleApiClient.unregisterConnectionFailedListener(this);
         mGoogleApiClient.disconnect();
+    }
+
+    protected void requestSignIn() {
+        if (signInClient == null) {
+            signInClient = GoogleApiClientFactory.createForSignIn(this, this);
+        }
+        Auth.GoogleSignInApi.silentSignIn(signInClient).setResultCallback(new ResultCallbacks<GoogleSignInResult>() {
+            @Override
+            public void onSuccess(@NonNull GoogleSignInResult result) {
+                onSuccessfulSignIn(result.getSignInAccount());
+            }
+
+            @Override
+            public void onFailure(@NonNull Status status) {
+                Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(signInClient);
+                startActivityForResult(signInIntent, RC_SIGN_IN);
+            }
+        });
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == RC_SIGN_IN) {
+            GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(data);
+            if (result.isSuccess()) {
+                onSuccessfulSignIn(result.getSignInAccount());
+            }
+        }
+    }
+
+    /**
+     * Called when a successful SignIn operation is made
+     *
+     * @param signInAccount {@link GoogleSignInAccount} of the user
+     */
+    @CallSuper
+    protected void onSuccessfulSignIn(GoogleSignInAccount signInAccount) {
+        PrefUtils.setSignedIn(this);
     }
 
     protected Toolbar getActionBarToolbar() {

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -30,6 +30,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 
@@ -197,6 +198,13 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         }
         closeNavDrawer();
         requestSignIn();
+    }
+
+    @Override
+    protected void onSuccessfulSignIn(GoogleSignInAccount signInAccount) {
+        super.onSuccessfulSignIn(signInAccount);
+        String welcome = getString(R.string.welcome_sign_in, signInAccount.getDisplayName());
+        Toast.makeText(this, welcome, Toast.LENGTH_SHORT).show();
     }
 
     void onDrawerItemClick(int itemId) {

--- a/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/common/GdgNavDrawerActivity.java
@@ -31,10 +31,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
-import com.google.android.gms.auth.api.signin.GoogleSignInResult;
-import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.gdg.frisbee.android.Const;
 import org.gdg.frisbee.android.R;
@@ -43,7 +40,6 @@ import org.gdg.frisbee.android.activity.SettingsActivity;
 import org.gdg.frisbee.android.api.Callback;
 import org.gdg.frisbee.android.api.model.plus.Person;
 import org.gdg.frisbee.android.app.App;
-import org.gdg.frisbee.android.app.GoogleApiClientFactory;
 import org.gdg.frisbee.android.cache.ModelCache;
 import org.gdg.frisbee.android.chapter.MainActivity;
 import org.gdg.frisbee.android.eventseries.TaggedEventSeries;
@@ -63,7 +59,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public abstract class GdgNavDrawerActivity extends GdgActivity {
-    private static final int RC_SIGN_IN = 101;
 
     private static final int DRAWER_HOME = 0;
     private static final int DRAWER_PULSE = 2;
@@ -95,7 +90,6 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
     ImageView mDrawerUserPicture;
     TextView mDrawerUserName;
     private ActionBarDrawerToggle mDrawerToggle;
-    private GoogleApiClient signInClient;
 
     @Override
     public void setContentView(int layoutResId) {
@@ -192,33 +186,17 @@ public abstract class GdgNavDrawerActivity extends GdgActivity {
         headerView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                onLoginClick();
+                onSignInClick();
             }
         });
     }
 
-    private void onLoginClick() {
+    private void onSignInClick() {
         if (PrefUtils.isSignedIn(this)) {
             return;
         }
         closeNavDrawer();
-        if (signInClient == null) {
-            signInClient = GoogleApiClientFactory.createForSignIn(this, this);
-        }
-        Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(signInClient);
-        startActivityForResult(signInIntent, RC_SIGN_IN);
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-
-        if (requestCode == RC_SIGN_IN) {
-            GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(data);
-            if (result.isSuccess()) {
-                PrefUtils.setSignedIn(this);
-            }
-        }
+        requestSignIn();
     }
 
     void onDrawerItemClick(int itemId) {

--- a/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/gdg/frisbee/android/fragment/SettingsFragment.java
@@ -147,7 +147,7 @@ public class SettingsFragment extends PreferenceFragment {
                         startActivityForResult(signInIntent, RC_SIGN_IN);
                     } else {
                         Auth.GoogleSignInApi.signOut(signInClient);
-                        PrefUtils.setLoggedOut(getActivity());
+                        PrefUtils.setSignedOut(getActivity());
                     }
                     return true;
                 }

--- a/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartActivity.java
+++ b/app/src/main/java/org/gdg/frisbee/android/onboarding/FirstStartActivity.java
@@ -227,7 +227,7 @@ public class FirstStartActivity extends GdgActivity implements
 
     @Override
     public void onSkippedSignIn() {
-        PrefUtils.setLoggedOut(this);
+        PrefUtils.setSignedOut(this);
 
         moveToStep3(false);
     }

--- a/app/src/main/java/org/gdg/frisbee/android/utils/PrefUtils.java
+++ b/app/src/main/java/org/gdg/frisbee/android/utils/PrefUtils.java
@@ -51,7 +51,7 @@ public final class PrefUtils {
         prefs(context).edit().putBoolean(SETTINGS_SIGNED_IN, true).apply();
     }
 
-    public static void setLoggedOut(Context context) {
+    public static void setSignedOut(Context context) {
         prefs(context).edit()
             .putBoolean(SETTINGS_SIGNED_IN, false)
             .apply();

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -35,7 +35,7 @@
   <string name="welcome_sign_in">مرحبا! %s</string>
   <string name="choose_home_gdg">اختر المجموعة المنتمي إليها</string>
   <string name="signin_with_google">تسجيل الدخول باستخدام جوجل</string>
-  <string name="confirm">تأكيد</string>                                            `
+  <string name="confirm">تأكيد</string>
   <string name="signin_description">التطبيق مدخل يدمج مع جوجل + وخدمات جوجل الأخرى. لاستخدام هذه الدالة أنت بحاجة لتسجيل الدخول إلى جوجل.</string>
   <string name="or">أو</string>
   <string name="skip">تخطي تسجيل الدخول</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -32,9 +32,10 @@
   <string name="cached_content">أنت غير متصل حاليا. وإليك بعض المحتوى المخزن مؤقتاً.</string>
   <string name="offline_alert">أنت غير متصل حاليا.</string>
   <string name="welcome">مرحبا</string>
+  <string name="welcome_sign_in">مرحبا! %s</string>
   <string name="choose_home_gdg">اختر المجموعة المنتمي إليها</string>
   <string name="signin_with_google">تسجيل الدخول باستخدام جوجل</string>
-  <string name="confirm">تأكيد</string>
+  <string name="confirm">تأكيد</string>                                            `
   <string name="signin_description">التطبيق مدخل يدمج مع جوجل + وخدمات جوجل الأخرى. لاستخدام هذه الدالة أنت بحاجة لتسجيل الدخول إلى جوجل.</string>
   <string name="or">أو</string>
   <string name="skip">تخطي تسجيل الدخول</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Nyní jsi off-line. Tady máš nějaký nacachovaný obsah.</string>
   <string name="offline_alert">Jsi off-line.</string>
   <string name="welcome">Vítej</string>
+  <string name="welcome_sign_in">Vítej! %s</string>
   <string name="choose_home_gdg">Nastav si svoje domovské GDG</string>
   <string name="signin_with_google">Přihlásit se přes Google</string>
   <string name="confirm">Potvrdit</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Du bist gerade offline. Hier ist eine ältere Version.</string>
   <string name="offline_alert">Du bist gerade offline.</string>
   <string name="welcome">Willkommen</string>
+  <string name="welcome_sign_in">Willkommen! %s</string>
   <string name="choose_home_gdg">Wähle deine Heimat-GDG</string>
   <string name="signin_with_google">Mit Google anmelden</string>
   <string name="confirm">Bestätigen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Te encuentras actualmente sin conexión. Aquí tienes contenido guardado.</string>
   <string name="offline_alert">Actualmente te encuentras sin conexión.</string>
   <string name="welcome">Bienvenida(o)</string>
+  <string name="welcome_sign_in">Bienvenida(o)! %s</string>
   <string name="choose_home_gdg">Elige tu GDG</string>
   <string name="signin_with_google">Iniciar con Google+</string>
   <string name="confirm">Confirmar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Vous êtes actuellement déconnecté. Voici le contenu mis en cache.</string>
   <string name="offline_alert">Vous êtes actuellement déconnecté.</string>
   <string name="welcome">Bienvenue</string>
+  <string name="welcome_sign_in">Bienvenue! %s</string>
   <string name="choose_home_gdg">Choisissez votre GDG</string>
   <string name="signin_with_google">Identifiez-vous avec Google</string>
   <string name="confirm">Confirmez</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">इस समय आप ऑफलाइन हैं ।  पहले से राखी हुई कुछ सूचना इस प्रकार है :</string>
   <string name="offline_alert">इस समय आप ऑफलाइन हैं ।</string>
   <string name="welcome">स्वागत है</string>
+  <string name="welcome_sign_in">स्वागत है! %s</string>
   <string name="choose_home_gdg">अपना जी डी जी चयन करें</string>
   <string name="signin_with_google">अपने गूगल अकाउंट के साथ जुड़ें</string>
   <string name="confirm">पुष्टि करें</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Jelenleg nincs net kapcsolat. Íme néhány elmentett tartalom.</string>
   <string name="offline_alert">Jelenleg nincs net kapcsolat.</string>
   <string name="welcome">Üdvözlet</string>
+  <string name="welcome_sign_in">Üdvözlet! %s</string>
   <string name="choose_home_gdg">Válaszd ki az otthoni GDG-det</string>
   <string name="signin_with_google">Bejelentkezés Google-lel</string>
   <string name="confirm">Jóváhagy</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Դուք հիմա անցանց եք: Ցուցադրվող բովանդակությունը քեշից է:</string>
   <string name="offline_alert">Դուք անցանց եք:</string>
   <string name="welcome">Բարի գալուստ</string>
+  <string name="welcome_sign_in">Բարի գալուստ! %s</string>
   <string name="choose_home_gdg">Ընտրեք ձեր GDG-ն</string>
   <string name="signin_with_google">Մուտք գործել Google-ով</string>
   <string name="confirm">Հաստատել</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Sei attualmente offline. Ecco alcuni contenuti nella cache.</string>
   <string name="offline_alert">Sei attualmente offline.</string>
   <string name="welcome">Benvenuto</string>
+  <string name="welcome_sign_in">Benvenuto! %s</string>
   <string name="choose_home_gdg">Scegli il GDG della tua città</string>
   <string name="signin_with_google">Accedi con Google</string>
   <string name="confirm">Conferma</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -33,6 +33,7 @@
   <string name="cached_content">現在オフラインです。キャッシュされたコンテンツを表示しています。</string>
   <string name="offline_alert">オフラインです</string>
   <string name="welcome">ようこそ</string>
+  <string name="welcome_sign_in">ようこそ! %s</string>
   <string name="choose_home_gdg">あなたのGDGを選択してください</string>
   <string name="signin_with_google">Googleアカウントでログイン</string>
   <string name="confirm">確認</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">현재 오프라인 상태입니다. 이전에 가져왔던 정보가 보여집니다.</string>
   <string name="offline_alert">현재 오프라인 상태입니다.</string>
   <string name="welcome">반갑습니다</string>
+  <string name="welcome_sign_in">반갑습니다! %s</string>
   <string name="choose_home_gdg">기본 GDG 선택하세요.</string>
   <string name="signin_with_google">Google로 로그인</string>
   <string name="confirm">확인</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Nėra ryšio. Rodomas ankstesnė informacija.</string>
   <string name="offline_alert">Nėra ryšio.</string>
   <string name="welcome">Labàdienà</string>
+  <string name="welcome_sign_in">Labàdienà! %s</string>
   <string name="choose_home_gdg">Pasirink artimiausią GDG</string>
   <string name="signin_with_google">Prisijungti su Google</string>
   <string name="confirm">Gerai</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Jij bent momenteel offline. Hier is een beetje opgeslagen inhoud.</string>
   <string name="offline_alert">Jij bent momenteel offline.</string>
   <string name="welcome">Welkom</string>
+  <string name="welcome_sign_in">Welkom! %s</string>
   <string name="choose_home_gdg">Kies je lokale GDG</string>
   <string name="signin_with_google">Inloggen met Google</string>
   <string name="confirm">Bevestigen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Brak połączenia. Dostępne są pobrane wcześniej informacje.</string>
   <string name="offline_alert">Brak połączenia.</string>
   <string name="welcome">Witamy</string>
+  <string name="welcome_sign_in">Witamy! %s</string>
   <string name="choose_home_gdg">Wybierz swój podstawowy GDG</string>
   <string name="signin_with_google">Zaloguj się poprzez Google</string>
   <string name="confirm">Potwierdź</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Você está atualmente offline. Segue o conteúdo do cache.</string>
   <string name="offline_alert">Você está offline.</string>
   <string name="welcome">Seja bem-vindo(a)</string>
+  <string name="welcome_sign_in">Seja bem-vindo(a)! %s</string>
   <string name="choose_home_gdg">Escolha o seu GDG de origem</string>
   <string name="signin_with_google">Faça sign-in com o Google</string>
   <string name="confirm">Confirme</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Você está atualmente off-line. Aqui está algum conteúdo em cache.</string>
   <string name="offline_alert">Você está atualmente off-line.</string>
   <string name="welcome">Bem-vindo</string>
+  <string name="welcome_sign_in">Bem-vindo! %s</string>
   <string name="choose_home_gdg">Escolha sua casa GDG</string>
   <string name="signin_with_google">Entrar com o Google</string>
   <string name="confirm">Confirmar</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">В настоящее время ты офлайн. Используется сохранённое в кэше содержание.</string>
   <string name="offline_alert">В настоящее время ты офлайн.</string>
   <string name="welcome">Добро пожаловать</string>
+  <string name="welcome_sign_in">Добро пожаловать! %s</string>
   <string name="choose_home_gdg">Выбери свой локальный GDG</string>
   <string name="signin_with_google">Войди с Google</string>
   <string name="confirm">Подтвердить</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Ste offline, zobrazuje sa nacachovaný obsah.</string>
   <string name="offline_alert">Ste offline.</string>
   <string name="welcome">Vitajte</string>
+  <string name="welcome_sign_in">Vitajte! %s</string>
   <string name="choose_home_gdg">Vyberte svoje domáce GDG</string>
   <string name="signin_with_google">Prihláste sa na Google účet</string>
   <string name="confirm">Potvrdiť</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">โหมดการใช้งานแบบออฟไลน์และใช้ข้อมูลจากแคช</string>
   <string name="offline_alert">คุณกำลังใช้งานแบบออฟไลน์</string>
   <string name="welcome">ยินดีต้อนรับ</string>
+  <string name="welcome_sign_in">ยินดีต้อนรับ! %s</string>
   <string name="choose_home_gdg">เลือก GDG ที่ใกล้คุณ</string>
   <string name="signin_with_google">ลงชื่อเข้าใช้งานด้วยบัญชี Google</string>
   <string name="confirm">ยืนยัน</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">Şu an internet bağlantınız yok. Aşağıda önbelleğe alınmış içerik bulunuyor.</string>
   <string name="offline_alert">Şu an internet bağlantınız yok.</string>
   <string name="welcome">Hoşgeldiniz</string>
+  <string name="welcome_sign_in">Hoşgeldiniz! %s</string>
   <string name="choose_home_gdg">Bulunduğunuz GDG\'yi seçin</string>
   <string name="signin_with_google">Google ile Giriş</string>
   <string name="confirm">Kabul Et</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -33,6 +33,7 @@
     </string>
   <string name="offline_alert">На даний момент ви не в мережі.</string>
   <string name="welcome">Ласкаво просимо</string>
+  <string name="welcome_sign_in">Ласкаво просимо! %s</string>
   <string name="choose_home_gdg">Виберіть GDG поряд з вами</string>
   <string name="signin_with_google">Вхід з Google</string>
   <string name="confirm">Підтвердити</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">您目前为离线状态，这里是缓存內容</string>
   <string name="offline_alert">您目前为离线状态</string>
   <string name="welcome">欢迎</string>
+  <string name="welcome_sign_in">欢迎! %s</string>
   <string name="choose_home_gdg">选择您所在地 GDG</string>
   <string name="signin_with_google">Google 登录</string>
   <string name="confirm">确定</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">您目前為離線狀態，這裡是快取內容</string>
   <string name="offline_alert">您目前為離線狀態</string>
   <string name="welcome">歡迎光臨</string>
+  <string name="welcome_sign_in">歡迎光臨! %s</string>
   <string name="choose_home_gdg">選擇您所在地 GDG</string>
   <string name="signin_with_google">Google 登入</string>
   <string name="confirm">確認</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">您目前為離線狀態，這裡是快取內容</string>
   <string name="offline_alert">您目前為離線狀態</string>
   <string name="welcome">歡迎光臨</string>
+  <string name="welcome_sign_in">歡迎光臨! %s</string>
   <string name="choose_home_gdg">選擇您所在地 GDG</string>
   <string name="signin_with_google">Google 登入</string>
   <string name="confirm">確認</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
   <string name="cached_content">You\'re currently offline. Here\'s some cached content.</string>
   <string name="offline_alert">You\'re currently offline.</string>
   <string name="welcome">Welcome</string>
+  <string name="welcome_sign_in">Welcome! %s</string>
   <string name="choose_home_gdg">Choose your home GDG</string>
   <string name="signin_with_google">Sign-in with Google</string>
   <string name="confirm">Confirm</string>


### PR DESCRIPTION
Currently, since we changed the way we sign in, users updated the app will not be automatically signed in. 

This PR moves sign in logic from NavDrawer back to `GdgActivity`. It is because I want to recover errors in any Activity we are. 

In `GdgActivity`, if our prefs says `isSignedIn` and Google Auth says it is not, we request sign in. 
And also it will first try `silentSignIn` and then normal sign in with a dialog. 

In case of an app update, `silentSignIn` should automatically work and the state will be preserved. 

The other use case is where the user revokes the app in Google privacy settings on the web. After a time, our app will request sign in again with a dialog. If the user really does not want it, they can press cancel and the app will never ask again. 

Also added a `onSuccessfulSignIn` which can be overridden in any Activity to be notified with a Login event. 

Fixes #616