### PR TITLE
Fix GET_ACCOUNTS permission missing crash

### DIFF
--- a/app/src/main/res/layout/dialog_feedback.xml
+++ b/app/src/main/res/layout/dialog_feedback.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical"
   android:paddingLeft="20dp"
@@ -33,15 +34,15 @@
     android:paddingTop="8dp"
     app:hintTextAppearance="@style/TextAppearance.GDG.FloatLabel">
 
-    <AutoCompleteTextView
+    <EditText
       android:id="@+id/feedback_email_text"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:completionThreshold="1"
       android:hint="@string/feedback_email_hint"
       android:imeOptions="actionDone"
       android:inputType="textEmailAddress"
-      android:singleLine="true" />
+      android:singleLine="true"
+      tools:ignore="Deprecated"/>
 
   </android.support.design.widget.TextInputLayout>
 


### PR DESCRIPTION
Remove AutocompleteTextView and accessing contacts.

This will fix the permission crash we are getting.

Instead of that, access to Google account and if we have a valid email there, hide the email address field.

Fixes crash https://fabric.io/gdgx/android/apps/org.gdg.frisbee.android/issues/581c99a40aeb16625b7ac358