### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_success:
   - if [ -n "$GITHUB_API_KEY" ]; then .buildscript/deploy_alpha.sh; fi
 
 script:
-  - ./gradlew check assembleDebug assembleDebugAndroidTest -Dorg.gradle.jvmargs="-Xms512m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false
+  - ./gradlew check assembleDebug assembleDebugAndroidTest -Dorg.gradle.jvmargs="-Xms512m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=true
   - .buildscript/firebase_tests.sh
 
 branches:


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
